### PR TITLE
feat: host-hook watchdog outside sand-host

### DIFF
--- a/adapters.sh
+++ b/adapters.sh
@@ -44,6 +44,7 @@ _adapters_data_dir() {
 }
 ADAPTERS_DATA="$(_adapters_data_dir)"
 CLIPROXY_DIR="${CLIPROXY_DIR:-$ADAPTERS_DATA/cliproxy-api}"
+HOST_HOOK_DIR="${HOST_HOOK_DIR:-$ADAPTERS_DATA/host-hook-watchdog}"
 LITELLM_DIR="${LITELLM_DIR:-$ADAPTERS_DATA/grok-model-bridge}"
 CLIPROXY_BIN="${CLIPROXY_BIN:-$HOME/go/bin/server}"
 CLIPROXY_PORT="${CLIPROXY_PORT:-8317}"
@@ -236,6 +237,11 @@ PY
     echo "cliproxy watchdog: running (pid $pid)"
   else
     echo "cliproxy watchdog: not running"
+  fi
+  if host_hook_watchdog_alive; then
+    echo "host-hook watchdog: running (pid $(cat "$HOST_HOOK_DIR/watchdog.pid"))"
+  else
+    echo "host-hook watchdog: not running"
   fi
   command -v litellm >/dev/null 2>&1 && echo "litellm:     OK ($(command -v litellm))" || echo "litellm:     not on PATH (uvx fallback ok)"
   command -v npx >/dev/null 2>&1 && echo "npx:         OK" || echo "npx:         MISSING"
@@ -1634,6 +1640,44 @@ cliproxy_watchdog_alive() {
   pid="$(cat "$pidfile" 2>/dev/null || true)"
   [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
   kill -0 "$pid" 2>/dev/null
+}
+
+host_hook_watchdog_alive() {
+  local pidfile="$HOST_HOOK_DIR/watchdog.pid" pid
+  [[ -f "$pidfile" ]] || return 1
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+install_host_hook_watchdog() {
+  local src="$ROOT/scripts/host-hook-watchdog.sh"
+  if [[ ! -f "$src" ]]; then
+    warn "missing $src — host-hook watchdog not installed"
+    return 1
+  fi
+  mkdir -p "$HOST_HOOK_DIR"
+  cp "$src" "$HOST_HOOK_DIR/watchdog.sh"
+  chmod +x "$HOST_HOOK_DIR/watchdog.sh"
+  if [[ -f "$ROOT/scripts/refresh-grok-if-expired.sh" ]]; then
+    cp "$ROOT/scripts/refresh-grok-if-expired.sh" "$HOST_HOOK_DIR/refresh-grok-if-expired.sh"
+    chmod +x "$HOST_HOOK_DIR/refresh-grok-if-expired.sh"
+  fi
+  if [[ -f "$ROOT/scripts/token-expired.py" ]]; then
+    cp "$ROOT/scripts/token-expired.py" "$HOST_HOOK_DIR/token-expired.py"
+    chmod +x "$HOST_HOOK_DIR/token-expired.py"
+  fi
+}
+
+start_host_hook_watchdog() {
+  install_host_hook_watchdog || return 1
+  if host_hook_watchdog_alive; then
+    log "host-hook watchdog already running"
+    return 0
+  fi
+  rm -f "$HOST_HOOK_DIR/watchdog.pid"
+  nohup "$HOST_HOOK_DIR/watchdog.sh" >>/tmp/sand-xai-watchdog.log 2>&1 &
+  log "host-hook watchdog started (pid $! log /tmp/sand-xai-watchdog.log)"
 }
 
 start_cliproxy() {
@@ -3247,7 +3291,7 @@ EOF
 # Rebuild host hook + CLIProxy after a sand-host / sand-data wipe.
 cmd_recover() {
   log "recover custom inference after a sand reset"
-  chmod +x "$ROOT/adapters" "$ROOT/adapters.sh" "$ROOT/scripts/ensure-xai-inference.sh" 2>/dev/null || true
+  chmod +x "$ROOT/adapters" "$ROOT/adapters.sh" "$ROOT/scripts/ensure-xai-inference.sh" "$ROOT/scripts/host-hook-watchdog.sh" "$ROOT/scripts/refresh-grok-if-expired.sh" 2>/dev/null || true
   mkdir -p "$HOME/.local/bin"
   cat >"$HOME/.local/bin/adapters" <<EOF
 #!/bin/sh
@@ -3271,6 +3315,7 @@ EOF
 
   install_cliproxy
   start_cliproxy || warn "cliproxy start failed — adapters start cliproxy"
+  start_host_hook_watchdog || warn "host-hook watchdog start failed"
 
   if [[ -f "$ENV_FILE" ]]; then
     cmd_restart_host || warn "host restart failed"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "scripts/ensure-xai-inference.sh",
     "scripts/restore-after-reset.sh",
     "scripts/bootstrap.sh",
+    "scripts/host-hook-watchdog.sh",
+    "scripts/refresh-grok-if-expired.sh",
+    "scripts/token-expired.py",
     "examples/cliproxy-openai-compat.yaml",
     "docs/GUIDE_CUSTOM_INFERENCE.md",
     "README.md",
@@ -49,6 +52,6 @@
   "scripts": {
     "adapters": "bash ./adapters.sh",
     "prepack": "test -x adapters.sh",
-    "test": "bash -n adapters.sh && bash -n adapters && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash ./adapters.sh help >/dev/null"
+    "test": "bash -n adapters.sh && bash -n adapters && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/host-hook-watchdog.sh && bash -n scripts/refresh-grok-if-expired.sh && bash ./adapters.sh help >/dev/null"
   }
 }

--- a/scripts/host-hook-watchdog.sh
+++ b/scripts/host-hook-watchdog.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Keep Grok Bot on grok-session (Heavy) after Cursor host-bundle wipes.
+# Lives outside ~/sand-host so a host reset does not delete this loop.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAND_HOST="${SAND_HOST_DIR:-$HOME/sand-host}"
+HOST_MAIN="$SAND_HOST/host-main.cjs"
+SESSION="$SAND_HOST/xai-prompt-session.cjs"
+SETUP="${GROK_BOT_SETUP:-$HOME/grok-bot-setup}"
+ENSURE="$SETUP/scripts/ensure-xai-inference.sh"
+NPM_ADAPTERS="$HOME/.local/lib/node_modules/grok-bot-setup/adapters.sh"
+CHECK_INTERVAL="${HOST_HOOK_CHECK_INTERVAL:-30}"
+LOG="${HOST_HOOK_LOG:-/tmp/sand-xai-watchdog.log}"
+PIDFILE="$ROOT/watchdog.pid"
+export PATH="$HOME/.local/bin:$HOME/.grok/bin:$PATH"
+
+wlog() { printf 'watchdog: %s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG"; }
+
+echo $$ >"$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+refresh_grok_if_expired() {
+  local helper=""
+  if [[ -x "$ROOT/refresh-grok-if-expired.sh" ]]; then helper="$ROOT/refresh-grok-if-expired.sh"; fi
+  if [[ -z "$helper" && -x "$SETUP/scripts/refresh-grok-if-expired.sh" ]]; then helper="$SETUP/scripts/refresh-grok-if-expired.sh"; fi
+  if [[ -z "$helper" && -x "$HOME/.local/lib/node_modules/grok-bot-setup/scripts/refresh-grok-if-expired.sh" ]]; then helper="$HOME/.local/lib/node_modules/grok-bot-setup/scripts/refresh-grok-if-expired.sh"; fi
+  [[ -n "$helper" ]] || return 0
+  "$helper" >/dev/null 2>&1 || true
+}
+
+adapters_bin() {
+  local repo="$SETUP/adapters.sh"
+  if [[ -f "$repo" ]] && [[ "$(wc -c < "$repo" 2>/dev/null || echo 0)" -gt 1000 ]]; then
+    printf '%s' "$repo"
+    return
+  fi
+  if [[ -x "$NPM_ADAPTERS" ]]; then
+    printf '%s' "$NPM_ADAPTERS"
+    return
+  fi
+  printf '%s' "$repo"
+}
+
+hook_ok() {
+  [[ -f "$SESSION" ]] && [[ -f "$HOST_MAIN" ]] && grep -q createXaiPromptSession "$HOST_MAIN"
+}
+
+recover_once() {
+  wlog "hook missing — patching"
+  if [[ ! -x "$ENSURE" ]]; then
+    wlog "missing $ENSURE"
+    return 1
+  fi
+  if ! "$ENSURE" >>"$LOG" 2>&1; then
+    wlog "ensure-xai-inference failed"
+    return 1
+  fi
+  if ! hook_ok; then
+    wlog "hook still missing after patch"
+    return 1
+  fi
+  local ad
+  ad="$(adapters_bin)"
+  if [[ ! -x "$ad" ]]; then
+    wlog "adapters.sh missing, hook patched but host not restarted"
+    return 1
+  fi
+  wlog "restarting host"
+  if ! "$ad" restart-host >>"$LOG" 2>&1; then
+    wlog "restart-host failed (hook is on disk)"
+    return 1
+  fi
+  wlog "recovered onto grok-session"
+  return 0
+}
+
+wlog "started (check=${CHECK_INTERVAL}s)"
+fails=0
+while true; do
+  refresh_grok_if_expired || true
+  if hook_ok; then
+    fails=0
+  else
+    if recover_once; then
+      fails=0
+    else
+      fails=$((fails + 1))
+      if [[ "$fails" -ge 3 ]]; then
+        wlog "recover failed $fails times; backing off 60s"
+        sleep 60
+        fails=0
+      fi
+    fi
+  fi
+  sleep "$CHECK_INTERVAL"
+done

--- a/scripts/refresh-grok-if-expired.sh
+++ b/scripts/refresh-grok-if-expired.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Silent grok CLI ping when ~/.grok/auth.json access token is expired.
+# Never prints tokens, env files, or keys. Never deletes the login file.
+# Never runs grok login interactively.
+set -u
+auth="$HOME/.grok/auth.json"
+[[ -f "$auth" ]] || exit 0
+command -v grok >/dev/null 2>&1 || exit 0
+py="$HOME/.local/share/grok-bot-adapters/host-hook-watchdog/token-expired.py"
+[[ -f "$py" ]] || py="$(dirname "$0")/token-expired.py"
+[[ -f "$py" ]] || exit 0
+expired="$(python3 "$py" "$auth" 2>/dev/null || echo 0)"
+[[ "$expired" == "1" ]] || exit 0
+grok models >/dev/null 2>&1 || true

--- a/scripts/token-expired.py
+++ b/scripts/token-expired.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import datetime, json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+try:
+    data = json.loads(path.read_text())
+except Exception:
+    print("0")
+    raise SystemExit(0)
+now = datetime.datetime.now(datetime.timezone.utc)
+expired = False
+entries = data.values() if isinstance(data, dict) else []
+for entry in entries:
+    if not isinstance(entry, dict):
+        continue
+    exp = entry.get("expires_at") or entry.get("expiresAt")
+    if exp is None:
+        continue
+    try:
+        if isinstance(exp, (int, float)):
+            ts = float(exp)
+            if ts > 1e12:
+                ts /= 1000.0
+            dt = datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+        else:
+            dt = datetime.datetime.fromisoformat(str(exp).replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=datetime.timezone.utc)
+        if dt < now:
+            expired = True
+            break
+    except Exception:
+        continue
+print("1" if expired else "0")


### PR DESCRIPTION
Keep Grok Bot on grok-session after Cursor host-bundle wipes.

Watchdog lives outside sand-host so a host reset does not delete the loop. adapters recover starts it if dead; it does not bounce a healthy host.

- scripts/host-hook-watchdog.sh
- scripts/refresh-grok-if-expired.sh
- scripts/token-expired.py
- adapters.sh recover starts the watchdog if the pid is dead
