### PR TITLE
feat: fleet-heavy dry-run wrapper for office Heavy cutover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           set -euo pipefail
           bash -n adapters.sh
           bash -n adapters
+          bash -n bin/fleet-heavy
+          bash -n bin/fleet-status
+          bash -n scripts/test-fleet-heavy.sh
           echo "bash -n OK"
 
       - name: ShellCheck
@@ -37,16 +40,22 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
           # Fail on errors only; warnings are noisy for a large interactive CLI.
-          shellcheck -S error adapters.sh adapters
+          shellcheck -S error adapters.sh adapters bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           echo "shellcheck OK"
 
       - name: CLI help smoke test
         run: |
           set -euo pipefail
-          chmod +x adapters adapters.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
           ./adapters.sh help | grep -q "npm"
           echo "help OK"
+
+      - name: Fleet-heavy stub tests
+        run: |
+          set -euo pipefail
+          bash ./scripts/test-fleet-heavy.sh
+          echo "fleet-heavy stub tests OK"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -96,5 +105,9 @@ jobs:
           set -euo pipefail
           bash -n adapters.sh
           bash -n adapters
-          chmod +x adapters adapters.sh
+          bash -n bin/fleet-heavy
+          bash -n bin/fleet-status
+          bash -n scripts/test-fleet-heavy.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
+          bash ./scripts/test-fleet-heavy.sh

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Or just run **`adapters`** with no args for the interactive menu.
 | `adapters restart-host` | Restart Sand host to pick up config |
 | `adapters help` | Full help |
 
+### Fleet Heavy (office cutover)
+
+Wrapper around `adapters use grok-session`. Default is **dry-run**. Live flick needs `--i-am-outside-chat` and `--go`, and it restarts every office agent on this computer. Never run it from a Grok Bot chat.
+
+```bash
+./bin/fleet-heavy --i-am-outside-chat          # preflight only
+./bin/fleet-status                             # same preflight
+./bin/fleet-heavy --i-am-outside-chat --go     # live. After Ricky GO, not from CoS.
+bash ./scripts/test-fleet-heavy.sh             # stub adapters only; never hits the live host
+```
+
+Story, blast radius, and the why-last-time-crashed notes: [`docs/FLEET_HEAVY_CUTOVER.md`](docs/FLEET_HEAVY_CUTOVER.md).
+
 ### Install targets
 
 `all` · `cliproxy` · `litellm` · `openai-oauth` · `claude` · `grok` · `codex` · `herdr` · `ghostty` · `tailscale` · `zellij` · `lazygit` · `login-agents`

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -284,11 +284,14 @@ enforce_gates() {
   if [[ ! -d "$AGENT_DATA" ]]; then
     refuse "agent-data missing or unreadable at $AGENT_DATA. Cannot prove recover is paused."
   fi
+  if [[ ! -r "$AGENT_DATA" || ! -x "$AGENT_DATA" ]]; then
+    refuse "agent-data not readable/traversable at $AGENT_DATA. Cannot prove recover is paused."
+  fi
   if [[ ! -d "$TRANSCRIPTS" ]]; then
     refuse "transcripts missing or unreadable at $TRANSCRIPTS. Cannot prove office is idle."
   fi
-  if [[ ! -r "$TRANSCRIPTS" ]]; then
-    refuse "transcripts not readable at $TRANSCRIPTS. Cannot prove office is idle."
+  if [[ ! -r "$TRANSCRIPTS" || ! -x "$TRANSCRIPTS" ]]; then
+    refuse "transcripts not readable/traversable at $TRANSCRIPTS. Cannot prove office is idle."
   fi
   local rec
   rec="$(recover_enabled || true)"

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -16,15 +16,28 @@ _script_dir() {
 }
 
 ROOT="$(cd "$(_script_dir)/.." && pwd)"
-ADAPTERS="${FLEET_ADAPTERS:-$ROOT/adapters.sh}"
-AGENT_DATA="${FLEET_AGENT_DATA:-$HOME/agent-data}"
-TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
-AUTH_FILE="${FLEET_GROK_AUTH:-$HOME/.grok/auth.json}"
-HOT_SECONDS="${FLEET_HOT_SECONDS:-15}"
-WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid}"
-COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-41943040}"
-MODEL="${FLEET_MODEL:-grok-4.6}"
-EFFORT="${FLEET_EFFORT:-medium}"
+ADAPTERS="$ROOT/adapters.sh"
+AGENT_DATA="$HOME/agent-data"
+TRANSCRIPTS="$AGENT_DATA/agent-transcripts"
+AUTH_FILE="$HOME/.grok/auth.json"
+HOT_SECONDS=15
+WATCHDOG_PIDFILE="${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid"
+COS_JSONL_WARN_BYTES=41943040
+MODEL="grok-4.6"
+EFFORT="medium"
+
+# Test harness only. Production cutover ignores these overrides.
+if [[ "${FLEET_ALLOW_TEST_OVERRIDES:-}" == "1" ]]; then
+  ADAPTERS="${FLEET_ADAPTERS:-$ADAPTERS}"
+  AGENT_DATA="${FLEET_AGENT_DATA:-$AGENT_DATA}"
+  TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
+  AUTH_FILE="${FLEET_GROK_AUTH:-$AUTH_FILE}"
+  HOT_SECONDS="${FLEET_HOT_SECONDS:-$HOT_SECONDS}"
+  WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-$WATCHDOG_PIDFILE}"
+  COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-$COS_JSONL_WARN_BYTES}"
+  MODEL="${FLEET_MODEL:-$MODEL}"
+  EFFORT="${FLEET_EFFORT:-$EFFORT}"
+fi
 
 WANT_GO=0
 OUTSIDE_CHAT=0
@@ -63,16 +76,18 @@ EOF
 }
 
 inside_sand() {
-  if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
-    return 0
-  fi
-  if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
-    return 1
+  if test_overrides_allowed; then
+    if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
+      return 0
+    fi
+    if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
+      return 1
+    fi
   fi
   local p="${PPID:-}"
   local i=0
   local cmd
-  while [[ "$i" -lt 12 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
+  while [[ "$i" -lt 32 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
     cmd=""
     if [[ -r "/proc/$p/cmdline" ]]; then
       cmd="$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null || true)"
@@ -90,26 +105,54 @@ inside_sand() {
   return 1
 }
 
+test_overrides_allowed() {
+  [[ "${FLEET_ALLOW_TEST_OVERRIDES:-}" == "1" ]]
+}
+
+# 0 = enabled, 1 = disabled, 2 = unreadable/invalid (caller must refuse on cutover)
 json_enabled() {
-  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get("enabled") else 1)' "$1"
+  python3 -c '
+import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+sys.exit(0 if d.get("enabled") else 1)
+' "$1"
 }
 
 recover_enabled() {
-  local f
-  if [[ -n "${FLEET_RECOVER_JSON:-}" && -f "${FLEET_RECOVER_JSON}" ]]; then
-    if json_enabled "$FLEET_RECOVER_JSON"; then
+  local f rc
+  if test_overrides_allowed && [[ -n "${FLEET_RECOVER_JSON:-}" ]]; then
+    if [[ ! -f "${FLEET_RECOVER_JSON}" ]]; then
+      return 1
+    fi
+    json_enabled "$FLEET_RECOVER_JSON"
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
       printf '%s\n' "$FLEET_RECOVER_JSON"
+      return 0
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      printf 'INVALID:%s\n' "$FLEET_RECOVER_JSON"
       return 0
     fi
     return 1
   fi
   if [[ ! -d "$AGENT_DATA" ]]; then
+    # Missing agent-data is handled by enforce_office_state; here treat as no recover.
     return 1
   fi
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
-    if json_enabled "$f"; then
+    json_enabled "$f"
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
       printf '%s\n' "$f"
+      return 0
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      printf 'INVALID:%s\n' "$f"
       return 0
     fi
   done < <(find "$AGENT_DATA" -path '*/automations/grok-session-recover/automation.json' 2>/dev/null || true)
@@ -131,12 +174,30 @@ hot_jsonls() {
   find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
 }
 
-# jsonl touched at or after cutover start (preflight race)
+# jsonl mtime >= cutover start (at or after). find -newermt is strictly after.
 mutated_since_t0() {
   if [[ -z "${CUTOVER_T0:-}" || ! -d "$TRANSCRIPTS" ]]; then
     return 0
   fi
-  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "@${CUTOVER_T0}" 2>/dev/null || true
+  python3 -c '
+import os,sys
+root,t0=sys.argv[1],int(sys.argv[2])
+hits=[]
+for dirpath,_,files in os.walk(root):
+    for name in files:
+        if not name.endswith(".jsonl"):
+            continue
+        path=os.path.join(dirpath,name)
+        try:
+            m=int(os.path.getmtime(path))
+        except OSError:
+            hits.append(path+":UNREADABLE")
+            continue
+        if m>=t0:
+            hits.append(path)
+for h in sorted(hits):
+    print(h)
+' "$TRANSCRIPTS" "$CUTOVER_T0" 2>/dev/null || true
 }
 
 jsonl_table() {
@@ -220,9 +281,21 @@ enforce_gates() {
   if inside_sand; then
     refuse "running under sand-host. Run me from tmux or a box shell, not CoS."
   fi
+  if [[ ! -d "$AGENT_DATA" ]]; then
+    refuse "agent-data missing or unreadable at $AGENT_DATA. Cannot prove recover is paused."
+  fi
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    refuse "transcripts missing or unreadable at $TRANSCRIPTS. Cannot prove office is idle."
+  fi
+  if [[ ! -r "$TRANSCRIPTS" ]]; then
+    refuse "transcripts not readable at $TRANSCRIPTS. Cannot prove office is idle."
+  fi
   local rec
   rec="$(recover_enabled || true)"
   if [[ -n "${rec:-}" ]]; then
+    if [[ "$rec" == INVALID:* ]]; then
+      refuse "Grok-session recover JSON unreadable/invalid (${rec#INVALID:}). Fix or remove it; do not guess."
+    fi
     refuse "Grok-session recover is enabled ($rec). Leave it paused."
   fi
   if watchdog_running; then
@@ -239,7 +312,7 @@ enforce_gates() {
   local mutated
   mutated="$(mutated_since_t0)"
   if [[ -n "$mutated" ]]; then
-    refuse "office jsonl mutated during preflight. Idle and re-run. Changed:"$'\n'"$mutated"
+    refuse "office jsonl mutated at or after cutover start. Idle and re-run. Changed:"$'\n'"$mutated"
   fi
 }
 
@@ -279,6 +352,12 @@ main() {
     exit 0
   fi
   CUTOVER_T0="${FLEET_CUTOVER_T0:-$(date +%s)}"
+  if ! test_overrides_allowed; then
+    unset FLEET_CUTOVER_T0 2>/dev/null || true
+    CUTOVER_T0="$(date +%s)"
+  elif [[ -n "${FLEET_CUTOVER_T0:-}" ]]; then
+    CUTOVER_T0="$FLEET_CUTOVER_T0"
+  fi
   preflight
   enforce_gates
   if [[ "$WANT_GO" -eq 1 ]]; then

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -30,6 +30,9 @@ WANT_GO=0
 OUTSIDE_CHAT=0
 MODE="cutover"
 EXIT_REFUSE=2
+# Epoch at cutover start — refuse if any jsonl mutates during slow preflight
+# (hot window alone can miss writes when preflight lasts longer than HOT_SECONDS).
+CUTOVER_T0=""
 
 log()  { printf '+ %s\n' "$*"; }
 warn() { printf '! %s\n' "$*" >&2; }
@@ -126,6 +129,14 @@ hot_jsonls() {
     return 0
   fi
   find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
+}
+
+# jsonl touched at or after cutover start (preflight race)
+mutated_since_t0() {
+  if [[ -z "${CUTOVER_T0:-}" || ! -d "$TRANSCRIPTS" ]]; then
+    return 0
+  fi
+  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "@${CUTOVER_T0}" 2>/dev/null || true
 }
 
 jsonl_table() {
@@ -225,6 +236,11 @@ enforce_gates() {
   if [[ -n "$hot" ]]; then
     refuse "office jsonl is hot (mid-turn). Idle first. Hot files:"$'\n'"$hot"
   fi
+  local mutated
+  mutated="$(mutated_since_t0)"
+  if [[ -n "$mutated" ]]; then
+    refuse "office jsonl mutated during preflight. Idle and re-run. Changed:"$'\n'"$mutated"
+  fi
 }
 
 run_go() {
@@ -262,6 +278,7 @@ main() {
     preflight
     exit 0
   fi
+  CUTOVER_T0="${FLEET_CUTOVER_T0:-$(date +%s)}"
   preflight
   enforce_gates
   if [[ "$WANT_GO" -eq 1 ]]; then

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# fleet-heavy — dry-run wrapper around adapters.sh use grok-session.
+# Default is dry-run. Live needs --i-am-outside-chat AND --go.
+# Never run this from a Grok Bot chat (CoS included). Tests never call live adapters.
+set -euo pipefail
+
+_script_dir() {
+  local src="${BASH_SOURCE[0]}"
+  local dir
+  while [[ -L "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")" && pwd
+}
+
+ROOT="$(cd "$(_script_dir)/.." && pwd)"
+ADAPTERS="${FLEET_ADAPTERS:-$ROOT/adapters.sh}"
+AGENT_DATA="${FLEET_AGENT_DATA:-$HOME/agent-data}"
+TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
+AUTH_FILE="${FLEET_GROK_AUTH:-$HOME/.grok/auth.json}"
+HOT_SECONDS="${FLEET_HOT_SECONDS:-15}"
+WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid}"
+COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-41943040}"
+MODEL="${FLEET_MODEL:-grok-4.6}"
+EFFORT="${FLEET_EFFORT:-medium}"
+
+WANT_GO=0
+OUTSIDE_CHAT=0
+MODE="cutover"
+EXIT_REFUSE=2
+
+log()  { printf '+ %s\n' "$*"; }
+warn() { printf '! %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+refuse() { printf 'REFUSE: %s\n' "$*" >&2; exit "$EXIT_REFUSE"; }
+
+usage() {
+  cat <<'EOF'
+fleet-heavy — office-wide SuperGrok Heavy cutover (wrapper around adapters)
+
+Default is dry-run. Does not restart the host.
+
+  fleet-heavy --i-am-outside-chat           # preflight, print the adapters command
+  fleet-heavy --i-am-outside-chat --go      # live flick. Restarts every office agent.
+  fleet-heavy status                        # preflight only
+  fleet-heavy --help
+
+Must refuse if: missing --i-am-outside-chat, running under sand-host,
+Grok-session recover is enabled, host-hook watchdog is running,
+~/.grok/auth.json missing, or any office jsonl is hot (mid-turn).
+
+Live command (after preflight):
+  adapters.sh use grok-session --model grok-4.6 --effort medium
+
+Never run from CoS. Never Sign Out of Cursor. Tests must stub adapters
+and must not pass --go against the live host.
+EOF
+}
+
+inside_sand() {
+  if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
+    return 0
+  fi
+  if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
+    return 1
+  fi
+  local p="${PPID:-}"
+  local i=0
+  local cmd
+  while [[ "$i" -lt 12 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
+    cmd=""
+    if [[ -r "/proc/$p/cmdline" ]]; then
+      cmd="$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null || true)"
+    fi
+    if [[ "$cmd" == *host-main.cjs* || "$cmd" == *sand-host* ]]; then
+      return 0
+    fi
+    if [[ -r "/proc/$p/status" ]]; then
+      p="$(awk '/^PPid:/{print $2}' "/proc/$p/status" 2>/dev/null || echo 1)"
+    else
+      break
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+json_enabled() {
+  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get("enabled") else 1)' "$1"
+}
+
+recover_enabled() {
+  local f
+  if [[ -n "${FLEET_RECOVER_JSON:-}" && -f "${FLEET_RECOVER_JSON}" ]]; then
+    if json_enabled "$FLEET_RECOVER_JSON"; then
+      printf '%s\n' "$FLEET_RECOVER_JSON"
+      return 0
+    fi
+    return 1
+  fi
+  if [[ ! -d "$AGENT_DATA" ]]; then
+    return 1
+  fi
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if json_enabled "$f"; then
+      printf '%s\n' "$f"
+      return 0
+    fi
+  done < <(find "$AGENT_DATA" -path '*/automations/grok-session-recover/automation.json' 2>/dev/null || true)
+  return 1
+}
+
+watchdog_running() {
+  local pid
+  [[ -f "$WATCHDOG_PIDFILE" ]] || return 1
+  pid="$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+hot_jsonls() {
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    return 0
+  fi
+  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
+}
+
+jsonl_table() {
+  local f size name
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    printf '(no transcripts at %s)\n' "$TRANSCRIPTS"
+    return 0
+  fi
+  printf '%-12s %s\n' "MiB" "jsonl"
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    size="$(wc -c < "$f" | tr -d ' ')"
+    name="${f#"$TRANSCRIPTS"/}"
+    awk -v s="$size" -v n="$name" -v warn="$COS_JSONL_WARN_BYTES" 'BEGIN {
+      mib = s / 1048576
+      flag = (s > warn) ? "  WARN>40MiB" : ""
+      printf "%8.1f    %s%s\n", mib, n, flag
+    }'
+  done < <(find "$TRANSCRIPTS" -name '*.jsonl' -type f 2>/dev/null | sort)
+}
+
+adapters_status() {
+  if [[ -x "$ADAPTERS" || -f "$ADAPTERS" ]]; then
+    "$ADAPTERS" status 2>/dev/null || true
+  else
+    warn "adapters missing at $ADAPTERS"
+  fi
+}
+
+live_cmd() {
+  printf '%s use grok-session --model %s --effort %s' "$ADAPTERS" "$MODEL" "$EFFORT"
+}
+
+preflight() {
+  local rec hot
+  printf '== fleet-heavy preflight ==\n'
+  printf 'mode: %s\n' "$MODE"
+  printf 'adapters: %s\n' "$ADAPTERS"
+  printf 'auth: %s\n' "$AUTH_FILE"
+  printf 'watchdog pidfile: %s\n' "$WATCHDOG_PIDFILE"
+  printf 'transcripts: %s\n' "$TRANSCRIPTS"
+  printf '\n-- adapters status --\n'
+  adapters_status
+  printf '\n-- office jsonl --\n'
+  jsonl_table
+  printf '\n-- gates --\n'
+  if inside_sand; then
+    printf 'inside sand-host: YES\n'
+  else
+    printf 'inside sand-host: no\n'
+  fi
+  rec="$(recover_enabled || true)"
+  if [[ -n "${rec:-}" ]]; then
+    printf 'grok-session recover: ENABLED (%s)\n' "$rec"
+  else
+    printf 'grok-session recover: paused/absent\n'
+  fi
+  if watchdog_running; then
+    printf 'host-hook watchdog: RUNNING (pid %s)\n' "$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+  else
+    printf 'host-hook watchdog: down\n'
+  fi
+  if [[ -f "$AUTH_FILE" ]]; then
+    printf 'grok oauth: present\n'
+  else
+    printf 'grok oauth: MISSING\n'
+  fi
+  hot="$(hot_jsonls)"
+  if [[ -n "$hot" ]]; then
+    printf 'hot jsonl (last %ss):\n%s\n' "$HOT_SECONDS" "$hot"
+  else
+    printf 'hot jsonl: none\n'
+  fi
+  printf '\nwould run:\n  %s\n' "$(live_cmd)"
+}
+
+enforce_gates() {
+  if [[ "$OUTSIDE_CHAT" -ne 1 ]]; then
+    refuse "missing --i-am-outside-chat. Run me from tmux or a box shell, not CoS."
+  fi
+  if inside_sand; then
+    refuse "running under sand-host. Run me from tmux or a box shell, not CoS."
+  fi
+  local rec
+  rec="$(recover_enabled || true)"
+  if [[ -n "${rec:-}" ]]; then
+    refuse "Grok-session recover is enabled ($rec). Leave it paused."
+  fi
+  if watchdog_running; then
+    refuse "host-hook watchdog is running. It will auto-restart onto Heavy and fight you."
+  fi
+  if [[ ! -f "$AUTH_FILE" ]]; then
+    refuse "no grok oauth at $AUTH_FILE. Do not grok login from this wrapper. Stop and tell Ricky."
+  fi
+  local hot
+  hot="$(hot_jsonls)"
+  if [[ -n "$hot" ]]; then
+    refuse "office jsonl is hot (mid-turn). Idle first. Hot files:"$'\n'"$hot"
+  fi
+}
+
+run_go() {
+  enforce_gates
+  if [[ ! -f "$ADAPTERS" ]]; then
+    die "adapters not found: $ADAPTERS"
+  fi
+  log "live flick: $(live_cmd)"
+  "$ADAPTERS" use grok-session --model "$MODEL" --effort "$EFFORT"
+}
+
+parse_args() {
+  if [[ "${1:-}" == "status" ]]; then
+    MODE="status"
+    shift || true
+  fi
+  if [[ "${1:-}" == "help" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --i-am-outside-chat) OUTSIDE_CHAT=1; shift ;;
+      --go) WANT_GO=1; shift ;;
+      --help|-h) usage; exit 0 ;;
+      status) MODE="status"; shift ;;
+      *) die "unknown flag: $1" ;;
+    esac
+  done
+}
+
+main() {
+  parse_args "$@"
+  if [[ "$MODE" == "status" ]]; then
+    preflight
+    exit 0
+  fi
+  preflight
+  enforce_gates
+  if [[ "$WANT_GO" -eq 1 ]]; then
+    run_go
+  else
+    log "dry-run only. Pass --go after you have read the preflight. This did not restart the host."
+  fi
+}
+
+main "$@"

--- a/bin/fleet-status
+++ b/bin/fleet-status
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(cd "$(dirname "$0")" && pwd)/fleet-heavy" status "$@"

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -98,7 +98,7 @@ Applies to `fleet-heavy` cutover (with or without `--go`), **not** to `fleet-hea
 
 - Missing `--i-am-outside-chat`
 - Parent walk finds `host-main.cjs` / `sand-host` (test-only `FLEET_FORCE_INSIDE=1` requires `FLEET_ALLOW_TEST_OVERRIDES=1`)
-- `agent-data` or transcripts dir missing/unreadable (cannot prove idle/recover paused)
+- `agent-data` or transcripts dir missing/unreadable/non-traversable (cannot prove idle/recover paused)
 - `Grok-session recover` is enabled, or its JSON is unreadable/invalid
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -1,0 +1,183 @@
+# Grok Heavy fleet cutover
+
+**Date:** 31 Aug 2026
+**Status:** story + dry-run CLI on this PR. No live switch. Merge/deploy later GO.
+**Owner:** CoS opened this PR via the VPS `GITHUB_TOKEN`. Terra QAs. tmux Grok is not briefed until Terra SHIPs. Ricky GOs the first flick from a non-chat shell.
+
+This is how we move every office Grok Bot agent off the Cursor meter onto SuperGrok Heavy when the weekly Grok Bot cap is gone, without repeating the hours-long crash.
+
+---
+
+## 1. What we are switching
+
+Not a per-agent toggle. Not the in-app Plan screen. Not Sign Out.
+
+One shared host on Grok Bot's computer runs every office agent. Completions today go to Cursor (`SAND_INFERENCE_PROVIDER=cursor`). The UI can still show `grok-4.6`. That does not mean Heavy.
+
+Heavy means:
+
+1. Patch `host-main.cjs` so sessions use `createXaiPromptSession`
+2. Write `~/sand-data/xai-inference.env` with `SAND_INFERENCE_PROVIDER=xai`
+3. Restart `host-main.cjs`
+
+Auth stays `~/.grok/auth.json` (already present). Cursor stays signed in. There is no in-app "change to Grok" switch. Signing out of Cursor deletes the Cursor account. Never do that.
+
+The adapters command that already exists:
+
+```bash
+PATH="$HOME/.local/bin:$HOME/.grok/bin:$PATH"
+/home/box/grok-bot-setup/adapters.sh use grok-session --model grok-4.6 --effort medium
+```
+
+`--effort medium` is the multi-agent setting. Default without the flag is `high`.
+
+This PR does **not** replace that command. It wraps it so a CoS turn cannot SIGTERM the host.
+
+Back to Cursor (documented, never from CoS, not as part of this PR's tests):
+
+```bash
+/home/box/grok-bot-setup/adapters.sh use cursor
+```
+
+Both restart the host unless `--no-restart`. `--no-restart` only writes files. A later restart is still required.
+
+---
+
+## 2. Blast radius
+
+Restart kills `host-main.cjs` for **every** Grok Bot agent on this computer: CoS, Development, Diagnostics, Back Market, Pump, Alex, Inbox, Growth, Workshop, Xero, Process, Restructuring, Finance, plus unused New Agent / New Bot rows.
+
+Gateway token can change. Desktop shows **Reconnecting**. Hard-refresh Grok Bot if it sticks.
+
+Shop Hermes, Telegram, Slack bots, and VPS tmux seats are not this host. They keep running.
+
+---
+
+## 3. Why last time crashed
+
+**What we did:** flipped Heavy from **inside the CoS chat**.
+
+**What happened:** chats dead for hours. Ricky duplicated CoS and ran a second Chief of Staff until the original came back.
+
+**Measured sizes (31 Aug), not a guess:**
+
+| Store | Size |
+|---|---|
+| CoS jsonl | **56.5 MiB**, 34,716 lines |
+| CoS conversation-blobs.db | **213 MiB** |
+| CoS agent folder | **248 MiB** |
+| Development jsonl | **47.4 MiB** |
+| Nothing is 400 MB | 400 MB was high. jsonl is now past 40. |
+
+**Mechanism:**
+
+1. CoS is mid-turn on the same process the switch SIGTERMs.
+2. Host restarts and reloads the swollen CoS transcript plus 213 MiB of blobs.
+3. Heavy path then tries to POST converted history to `cli-chat-proxy.grok.com` (300s timeout), then trims to 400k chars. Trim is too late.
+4. Gateway token changes. Every agent shows Reconnecting.
+5. Overnight Cursor host wipes also drop the Heavy hook. The recover routine that auto-`adapters recover`s is **paused on purpose**. Leave it paused during any Cursor-meter week.
+
+**Rule that stands:** never switch Heavy from inside the CoS chat. Duplicate-chat is crash recovery, not a procedure.
+
+---
+
+## 4. The flick switch in this PR
+
+Wrapper, not a new inference stack.
+
+```
+bin/fleet-heavy
+bin/fleet-status
+```
+
+VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: Ricky (or a non-chat shell on Grok Bot's computer) runs the command.
+
+### 4.1 Must refuse (exit 2)
+
+- Missing `--i-am-outside-chat`
+- Parent walk finds `host-main.cjs` / `sand-host` (or `FLEET_FORCE_INSIDE=1`)
+- `Grok-session recover` is enabled
+- Host-hook watchdog is running
+- `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
+- Any office jsonl is hot in the last N seconds (mid-turn)
+
+### 4.2 Default is dry-run
+
+Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart.
+
+### 4.3 Live needs both flags
+
+```bash
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat --go
+```
+
+That is the only path that calls:
+
+`adapters.sh use grok-session --model grok-4.6 --effort medium`
+
+### 4.4 Tests
+
+`scripts/test-fleet-heavy.sh` uses a stub `adapters` binary. It may pass `--go` against the stub. It must never point `FLEET_ADAPTERS` at the live `adapters.sh` on this host.
+
+### 4.5 Pause meaning
+
+There is no official "pause all Grok Bot agents" CLI. Pause = every office agent idle (no streaming), recover off, watchdog off. Do not start a CoS turn "to pause people". Idle is enough.
+
+---
+
+## 5. After 8 Sep 2026
+
+Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen so Ultra returns at $0. Linking does not stack extra Ultra. That is billing. It is not this host patch. Do both: plan link **and** grok-session host, or you can have a paid Heavy plan while completions still hit Cursor.
+
+---
+
+## 6. Critique of this plan
+
+**What is solid**
+
+- Uses the adapters path that already worked on 23 Aug.
+- Moves the kill out of CoS.
+- Names the real size (56.5 MiB jsonl, not 400 MB).
+- Keeps Cursor login and Grok oauth.
+- `--effort medium` for a 15-agent host.
+- Tests never restart the live host.
+
+**What is still weak**
+
+- Restart still reloads the 56.5 MiB CoS jsonl. External flick avoids *self-kill*, not *fat-chat reload*. First smoke is a **small** agent (Finance), not CoS. CoS last.
+- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can start between check and SIGTERM. `--go` window is short; fail closed if any jsonl mutates during preflight.
+- VPS tmux cannot yet press the button on this host. First ship is local CLI plus a printed command. Remote SSH/bridge is a later GO.
+- Overnight Cursor host wipes will drop the hook again. After we are on Heavy, the paused recover job / watchdog need a **separate** GO.
+- Fat transcripts are the underlying disease. This switch does not compact CoS. Do not auto-trim jsonl in the wrapper.
+
+**What we will not do**
+
+- Flip from CoS.
+- `adapters use cursor` as an undo from CoS.
+- Delete or Sign Out Cursor.
+- Delete CoS to "make the file smaller".
+- Install a second CoS as the happy path.
+- Gas Town / Kilroy / HQ as the switcher.
+- Brief tmux:grok until Terra SHIPs this PR.
+
+---
+
+## 7. Build order
+
+1. This PR (story + `bin/fleet-heavy` + smashable tests).
+2. Terra QA: dry-run only on the live host. No `use grok-session` until Ricky GO.
+3. After Terra SHIP, discuss whether tmux:grok should own later work (remote trigger). Not before.
+4. Ricky GO from a non-CoS shell: `fleet-heavy --i-am-outside-chat --go`
+5. Smoke Finance (tiny chat), then Development, CoS last.
+6. Later GO: remote trigger from VPS tmux, and whether to re-arm recover/watchdog.
+
+---
+
+## 8. First command (after Terra, after GO, not now)
+
+```bash
+# on Grok Bot's computer, not in CoS, not on the VPS
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat
+# read the preflight
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat --go
+```

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -2,7 +2,7 @@
 
 **Date:** 31 Aug 2026
 **Status:** story + dry-run CLI on this PR. No live switch. Merge/deploy later GO.
-**Owner:** CoS opened this PR via the VPS `GITHUB_TOKEN`. Terra QAs. tmux Grok is not briefed until Terra SHIPs. Ricky GOs the first flick from a non-chat shell.
+**Owner:** Opened as `panrix:feat/fleet-heavy` → BlockedPath PR #3 via VPS `gh` (panrix). Do not use the dead `GITHUB_TOKEN` PAT. Terra QAs. Ricky GOs the first flick from a non-chat shell on Grok Bot's computer.
 
 This is how we move every office Grok Bot agent off the Cursor meter onto SuperGrok Heavy when the weekly Grok Bot cap is gone, without repeating the hours-long crash.
 
@@ -100,6 +100,7 @@ VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: R
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
 - Any office jsonl is hot in the last N seconds (mid-turn)
+- Any office jsonl mutates at or after cutover start (preflight race; covers the case where preflight lasts longer than the hot window)
 
 ### 4.2 Default is dry-run
 
@@ -145,7 +146,7 @@ Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen 
 **What is still weak**
 
 - Restart still reloads the 56.5 MiB CoS jsonl. External flick avoids *self-kill*, not *fat-chat reload*. First smoke is a **small** agent (Finance), not CoS. CoS last.
-- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can start between check and SIGTERM. `--go` window is short; fail closed if any jsonl mutates during preflight.
+- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can still start between the final gate and SIGTERM. The wrapper also refuses if any jsonl mutates after cutover start (covers slow preflight vs short hot window). Residual race after the last check remains.
 - VPS tmux cannot yet press the button on this host. First ship is local CLI plus a printed command. Remote SSH/bridge is a later GO.
 - Overnight Cursor host wipes will drop the hook again. After we are on Heavy, the paused recover job / watchdog need a **separate** GO.
 - Fat transcripts are the underlying disease. This switch does not compact CoS. Do not auto-trim jsonl in the wrapper.
@@ -158,7 +159,7 @@ Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen 
 - Delete CoS to "make the file smaller".
 - Install a second CoS as the happy path.
 - Gas Town / Kilroy / HQ as the switcher.
-- Brief tmux:grok until Terra SHIPs this PR.
+- Live flick / remote bridge / re-arm recover-watchdog without Ricky GO.
 
 ---
 

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -92,19 +92,24 @@ bin/fleet-status
 
 VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: Ricky (or a non-chat shell on Grok Bot's computer) runs the command.
 
-### 4.1 Must refuse (exit 2)
+### 4.1 Must refuse on cutover path (exit 2)
+
+Applies to `fleet-heavy` cutover (with or without `--go`), **not** to `fleet-heavy status` / `fleet-status` (those are ungated preflight printers).
 
 - Missing `--i-am-outside-chat`
-- Parent walk finds `host-main.cjs` / `sand-host` (or `FLEET_FORCE_INSIDE=1`)
-- `Grok-session recover` is enabled
+- Parent walk finds `host-main.cjs` / `sand-host` (test-only `FLEET_FORCE_INSIDE=1` requires `FLEET_ALLOW_TEST_OVERRIDES=1`)
+- `agent-data` or transcripts dir missing/unreadable (cannot prove idle/recover paused)
+- `Grok-session recover` is enabled, or its JSON is unreadable/invalid
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
 - Any office jsonl is hot in the last N seconds (mid-turn)
-- Any office jsonl mutates at or after cutover start (preflight race; covers the case where preflight lasts longer than the hot window)
+- Any office jsonl mtime is **at or after** cutover start (preflight race)
+
+Test harness overrides (`FLEET_ADAPTERS`, `FLEET_FORCE_*`, path/auth stubs, etc.) are ignored unless `FLEET_ALLOW_TEST_OVERRIDES=1`.
 
 ### 4.2 Default is dry-run
 
-Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart.
+Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart. Note: `adapters status` may chmod the CLIProxy binary executable as a side effect of that existing command — dry-run is not a pure no-op filesystem-wise, but it does not switch inference or restart the host.
 
 ### 4.3 Live needs both flags
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "scripts/ensure-xai-inference.sh",
     "scripts/restore-after-reset.sh",
     "scripts/bootstrap.sh",
+    "scripts/test-fleet-heavy.sh",
+    "bin/fleet-heavy",
+    "bin/fleet-status",
+    "docs/FLEET_HEAVY_CUTOVER.md",
     "examples/cliproxy-openai-compat.yaml",
     "docs/GUIDE_CUSTOM_INFERENCE.md",
     "README.md",
@@ -49,6 +53,6 @@
   "scripts": {
     "adapters": "bash ./adapters.sh",
     "prepack": "test -x adapters.sh",
-    "test": "bash -n adapters.sh && bash -n adapters && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash ./adapters.sh help >/dev/null"
+    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/test-fleet-heavy.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh"
   }
 }

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -103,6 +103,14 @@ assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
 touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 
+# Mutation during preflight: file newer than CUTOVER_T0 but outside the hot window.
+# Simulates a turn that started at cutover start then went idle before the final gate.
+touch -d "5 seconds ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl mutated since cutover t0" \
+  env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$(( $(date +%s) - 30 ))" \
+  "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
 : > "$FLEET_STUB_LOG"
 assert_exit 0 "dry-run succeeds" \
   "$FLEET" --i-am-outside-chat

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -67,6 +67,8 @@ echo "STUB $*"
 STUB
 chmod +x "$WORKDIR/stub-adapters" "$FLEET" "$ROOT/bin/fleet-status"
 
+# Harness overrides are gated. Without the allow flag they must be ignored.
+export FLEET_ALLOW_TEST_OVERRIDES=1
 export FLEET_FORCE_OUTSIDE=1
 export FLEET_ADAPTERS="$WORKDIR/stub-adapters"
 export FLEET_AGENT_DATA="$WORKDIR/agent-data"
@@ -83,9 +85,34 @@ assert_exit 2 "refuse without --i-am-outside-chat" \
 assert_exit 2 "refuse if inside sand-host" \
   env FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
 
+# Prod must ignore FORCE_INSIDE without the allow flag.
+# Without overrides, this VPS lacks office agent-data → refuse missing state, NOT sand-host.
+assert_exit 2 "FORCE_INSIDE ignored without allow flag" \
+  env -u FLEET_ALLOW_TEST_OVERRIDES FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
+if grep -q 'running under sand-host' /tmp/fleet-test-err; then
+  printf 'FAIL FORCE_INSIDE without allow still tripped sand gate\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  FORCE_INSIDE without allow did not trip sand gate\n'
+  PASS=$((PASS + 1))
+fi
+assert_exit 2 "allow+FORCE_INSIDE still refuses" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 \
+  "$FLEET" --i-am-outside-chat
+if ! grep -q 'running under sand-host' /tmp/fleet-test-err; then
+  printf 'FAIL allow+FORCE_INSIDE should refuse via sand gate\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  allow+FORCE_INSIDE refused via sand gate\n'
+  PASS=$((PASS + 1))
+fi
 printf '%s\n' '{"name":"Grok-session recover","enabled":true}' \
   > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
 assert_exit 2 "refuse if recover enabled" \
+  "$FLEET" --i-am-outside-chat
+printf '%s\n' 'NOT-JSON' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+assert_exit 2 "refuse if recover JSON invalid" \
   "$FLEET" --i-am-outside-chat
 printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
   > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
@@ -98,13 +125,23 @@ rm -f "$WORKDIR/watchdog/watchdog.pid"
 assert_exit 2 "refuse if no grok oauth" \
   env FLEET_GROK_AUTH="$WORKDIR/missing-auth.json" "$FLEET" --i-am-outside-chat
 
+assert_exit 2 "refuse if transcripts missing" \
+  env FLEET_TRANSCRIPTS="$WORKDIR/missing-transcripts" "$FLEET" --i-am-outside-chat
+
 touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
 touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 
-# Mutation during preflight: file newer than CUTOVER_T0 but outside the hot window.
-# Simulates a turn that started at cutover start then went idle before the final gate.
+# Equality boundary: mtime == CUTOVER_T0 must refuse (at or after).
+T0=$(( $(date +%s) - 30 ))
+touch -d "@${T0}" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl mtime equals cutover t0" \
+  env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$T0" \
+  "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
+# Strictly after T0, outside hot window.
 touch -d "5 seconds ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl mutated since cutover t0" \
   env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$(( $(date +%s) - 30 ))" \

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -128,6 +128,13 @@ assert_exit 2 "refuse if no grok oauth" \
 assert_exit 2 "refuse if transcripts missing" \
   env FLEET_TRANSCRIPTS="$WORKDIR/missing-transcripts" "$FLEET" --i-am-outside-chat
 
+chmod 000 "$WORKDIR/agent-data"
+assert_exit 2 "refuse if agent-data unreadable" \
+  "$FLEET" --i-am-outside-chat
+chmod 755 "$WORKDIR/agent-data"
+# restore nested perms after parent chmod 000
+chmod -R u+rwX "$WORKDIR/agent-data" 2>/dev/null || true
+
 touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Smashable tests for bin/fleet-heavy. Never call live adapters or --go on the host.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FLEET="$ROOT/bin/fleet-heavy"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local want="$1"
+  local name="$2"
+  shift 2
+  local rc=0
+  "$@" >/tmp/fleet-test-out 2>/tmp/fleet-test-err || rc=$?
+  if [[ "$rc" -eq "$want" ]]; then
+    printf 'ok  %s (exit %s)\n' "$name" "$rc"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s (want %s got %s)\n' "$name" "$want" "$rc"
+    sed 's/^/  out: /' /tmp/fleet-test-out | tail -20
+    sed 's/^/  err: /' /tmp/fleet-test-err | tail -20
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_in() {
+  local needle="$1"
+  local file="$2"
+  local name="$3"
+  if grep -q -- "$needle" "$file"; then
+    printf 'FAIL %s (found %s in %s)\n' "$name" "$needle" "$file"
+    FAIL=$((FAIL + 1))
+  else
+    printf 'ok  %s\n' "$name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d /tmp/fleet-heavy-test.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/agent-data/agent-transcripts/tiny" \
+         "$WORKDIR/agent-data/agents/test/automations/grok-session-recover" \
+         "$WORKDIR/watchdog" \
+         "$WORKDIR/grok"
+printf '{}\n' > "$WORKDIR/grok/auth.json"
+printf 'paused chat\n' > "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+
+cat > "$WORKDIR/stub-adapters" << 'STUB'
+#!/usr/bin/env bash
+log="${FLEET_STUB_LOG:-/tmp/fleet-stub.log}"
+printf '%s\n' "$*" >> "$log"
+if [[ "${1:-}" == "status" ]]; then
+  echo "provider: cursor"
+  echo "host: up"
+  echo "grok oauth: present"
+  exit 0
+fi
+if [[ "${1:-}" == "use" ]]; then
+  echo "STUB_USE $*"
+  exit 0
+fi
+echo "STUB $*"
+STUB
+chmod +x "$WORKDIR/stub-adapters" "$FLEET" "$ROOT/bin/fleet-status"
+
+export FLEET_FORCE_OUTSIDE=1
+export FLEET_ADAPTERS="$WORKDIR/stub-adapters"
+export FLEET_AGENT_DATA="$WORKDIR/agent-data"
+export FLEET_TRANSCRIPTS="$WORKDIR/agent-data/agent-transcripts"
+export FLEET_GROK_AUTH="$WORKDIR/grok/auth.json"
+export FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid"
+export FLEET_HOT_SECONDS=15
+export FLEET_STUB_LOG="$WORKDIR/stub.log"
+: > "$FLEET_STUB_LOG"
+
+assert_exit 2 "refuse without --i-am-outside-chat" \
+  env FLEET_FORCE_OUTSIDE=1 "$FLEET"
+
+assert_exit 2 "refuse if inside sand-host" \
+  env FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
+
+printf '%s\n' '{"name":"Grok-session recover","enabled":true}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+assert_exit 2 "refuse if recover enabled" \
+  "$FLEET" --i-am-outside-chat
+printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+
+echo "$$" > "$WORKDIR/watchdog/watchdog.pid"
+assert_exit 2 "refuse if watchdog running" \
+  "$FLEET" --i-am-outside-chat
+rm -f "$WORKDIR/watchdog/watchdog.pid"
+
+assert_exit 2 "refuse if no grok oauth" \
+  env FLEET_GROK_AUTH="$WORKDIR/missing-auth.json" "$FLEET" --i-am-outside-chat
+
+touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl hot" \
+  env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "dry-run succeeds" \
+  "$FLEET" --i-am-outside-chat
+assert_not_in "use grok-session" "$FLEET_STUB_LOG" "dry-run did not call adapters use"
+if grep -q "^status$" "$FLEET_STUB_LOG"; then
+  printf 'ok  dry-run called adapters status\n'
+  PASS=$((PASS + 1))
+else
+  printf 'FAIL dry-run should call adapters status\n'
+  FAIL=$((FAIL + 1))
+fi
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "go against stub adapters" \
+  "$FLEET" --i-am-outside-chat --go
+if grep -q "use grok-session --model grok-4.6 --effort medium" "$FLEET_STUB_LOG"; then
+  printf 'ok  go called stub with medium effort\n'
+  PASS=$((PASS + 1))
+else
+  printf 'FAIL go did not call stub use grok-session medium\n'
+  cat "$FLEET_STUB_LOG"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "adapters.sh" "$FLEET_STUB_LOG"; then
+  printf 'FAIL stub log mentions adapters.sh\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  stub log has no live adapters.sh path\n'
+  PASS=$((PASS + 1))
+fi
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "status without flag" \
+  "$FLEET" status
+assert_not_in "use grok-session" "$FLEET_STUB_LOG" "status did not call adapters use"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Dry-run fleet-heavy wrapper around adapters use grok-session. Story in docs/FLEET_HEAVY_CUTOVER.md. Tests stub adapters. Do not pass --go on the live host. No tmux:grok until Terra SHIPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guarded fleet cutover command with dry-run preflight and explicit safety checks before live execution.
  * Added a fleet status command for reviewing adapter, authentication, watchdog, recovery, and transcript conditions.
  * Live cutover requires explicit confirmation and must be initiated outside chat.

* **Documentation**
  * Added usage guidance, safety limitations, blast-radius details, recovery notes, and testing instructions.

* **Tests**
  * Added end-to-end stub-based coverage for safety gates, status checks, dry runs, and live execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->