### PR TITLE
feat: grok OAuth keepalive on the #4 policy bench

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,11 @@ jobs:
           bash -n adapters
           bash -n bin/fleet-heavy
           bash -n bin/fleet-status
+          bash -n bin/grok-auth-status
+          bash -n bin/grok-auth-cutover-status
+          bash -n scripts/refresh-grok-if-expired.sh
           bash -n scripts/test-fleet-heavy.sh
+          bash -n scripts/test-grok-auth-keepalive.sh
           echo "bash -n OK"
 
       - name: ShellCheck
@@ -40,13 +44,13 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
           # Fail on errors only; warnings are noisy for a large interactive CLI.
-          shellcheck -S error adapters.sh adapters bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
+          shellcheck -S error adapters.sh adapters bin/fleet-heavy bin/fleet-status bin/grok-auth-status bin/grok-auth-cutover-status scripts/refresh-grok-if-expired.sh scripts/test-fleet-heavy.sh
           echo "shellcheck OK"
 
       - name: CLI help smoke test
         run: |
           set -euo pipefail
-          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status bin/grok-auth-status bin/grok-auth-cutover-status scripts/refresh-grok-if-expired.sh scripts/test-fleet-heavy.sh scripts/test-grok-auth-keepalive.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
           ./adapters.sh help | grep -q "npm"
           echo "help OK"
@@ -56,6 +60,12 @@ jobs:
           set -euo pipefail
           bash ./scripts/test-fleet-heavy.sh
           echo "fleet-heavy stub tests OK"
+
+      - name: Grok auth keepalive stub tests
+        run: |
+          set -euo pipefail
+          bash ./scripts/test-grok-auth-keepalive.sh
+          echo "grok-auth keepalive stub tests OK"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -107,7 +117,12 @@ jobs:
           bash -n adapters
           bash -n bin/fleet-heavy
           bash -n bin/fleet-status
+          bash -n bin/grok-auth-status
+          bash -n bin/grok-auth-cutover-status
+          bash -n scripts/refresh-grok-if-expired.sh
           bash -n scripts/test-fleet-heavy.sh
-          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
+          bash -n scripts/test-grok-auth-keepalive.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status bin/grok-auth-status bin/grok-auth-cutover-status scripts/refresh-grok-if-expired.sh scripts/test-fleet-heavy.sh scripts/test-grok-auth-keepalive.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
           bash ./scripts/test-fleet-heavy.sh
+          bash ./scripts/test-grok-auth-keepalive.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           set -euo pipefail
           bash -n adapters.sh
           bash -n adapters
+          bash -n bin/fleet-heavy
+          bash -n bin/fleet-status
+          bash -n scripts/test-fleet-heavy.sh
           echo "bash -n OK"
 
       - name: ShellCheck
@@ -37,16 +40,22 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq shellcheck
           # Fail on errors only; warnings are noisy for a large interactive CLI.
-          shellcheck -S error adapters.sh adapters
+          shellcheck -S error adapters.sh adapters bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           echo "shellcheck OK"
 
       - name: CLI help smoke test
         run: |
           set -euo pipefail
-          chmod +x adapters adapters.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
           ./adapters.sh help | grep -q "npm"
           echo "help OK"
+
+      - name: Fleet-heavy stub tests
+        run: |
+          set -euo pipefail
+          bash ./scripts/test-fleet-heavy.sh
+          echo "fleet-heavy stub tests OK"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -96,5 +105,9 @@ jobs:
           set -euo pipefail
           bash -n adapters.sh
           bash -n adapters
-          chmod +x adapters adapters.sh
+          bash -n bin/fleet-heavy
+          bash -n bin/fleet-status
+          bash -n scripts/test-fleet-heavy.sh
+          chmod +x adapters adapters.sh bin/fleet-heavy bin/fleet-status scripts/test-fleet-heavy.sh
           ./adapters help | grep -q "Grok Bot adapters CLI"
+          bash ./scripts/test-fleet-heavy.sh

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Or just run **`adapters`** with no args for the interactive menu.
 | `adapters restart-host` | Restart Sand host to pick up config |
 | `adapters help` | Full help |
 
+### Fleet Heavy (office cutover)
+
+Wrapper around `adapters use grok-session`. Default is **dry-run**. Live flick needs `--i-am-outside-chat` and `--go`, and it restarts every office agent on this computer. Never run it from a Grok Bot chat.
+
+```bash
+./bin/fleet-heavy --i-am-outside-chat          # preflight only
+./bin/fleet-status                             # same preflight
+./bin/fleet-heavy --i-am-outside-chat --go     # live. After Ricky GO, not from CoS.
+bash ./scripts/test-fleet-heavy.sh             # stub adapters only; never hits the live host
+```
+
+Story, blast radius, and the why-last-time-crashed notes: [`docs/FLEET_HEAVY_CUTOVER.md`](docs/FLEET_HEAVY_CUTOVER.md).
+
 ### Install targets
 
 `all` · `cliproxy` · `litellm` · `openai-oauth` · `claude` · `grok` · `codex` · `herdr` · `ghostty` · `tailscale` · `zellij` · `lazygit` · `login-agents`

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ bash ./scripts/test-fleet-heavy.sh             # stub adapters only; never hits 
 
 Story, blast radius, and the why-last-time-crashed notes: [`docs/FLEET_HEAVY_CUTOVER.md`](docs/FLEET_HEAVY_CUTOVER.md).
 
+### Grok OAuth keepalive (probe only)
+
+Host `/health` 200 does **not** mean the access `key` in `~/.grok/auth.json` is live. Probe before a weekly Cursor → Heavy cutover. Never from chat. Never `--go`.
+
+```bash
+./bin/grok-auth-status                 # exists / has_key / expires_at / ok|soon|EXPIRED
+./bin/grok-auth-cutover-status         # hook + oauth + watchdog pid + recover armed?
+bash ./scripts/refresh-grok-if-expired.sh   # skip, or grok models, or refresh-failed
+# if EXPIRED: /home/box/.grok/bin/grok login --device-auth   (human, desktop)
+bash ./scripts/test-grok-auth-keepalive.sh  # stub fixtures; never live login
+```
+
+Two doors (do not weld): hook missing → `adapters.sh recover` / `fleet-heavy --go` (Ricky, paused). Token dead → M1 / human device-auth. Do not start `host-hook-watchdog.sh` from the oauth path. Details: [`docs/GROK_AUTH_KEEPALIVE.md`](docs/GROK_AUTH_KEEPALIVE.md).
+
 ### Install targets
 
 `all` · `cliproxy` · `litellm` · `openai-oauth` · `claude` · `grok` · `codex` · `herdr` · `ghostty` · `tailscale` · `zellij` · `lazygit` · `login-agents`

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -284,11 +284,14 @@ enforce_gates() {
   if [[ ! -d "$AGENT_DATA" ]]; then
     refuse "agent-data missing or unreadable at $AGENT_DATA. Cannot prove recover is paused."
   fi
+  if [[ ! -r "$AGENT_DATA" || ! -x "$AGENT_DATA" ]]; then
+    refuse "agent-data not readable/traversable at $AGENT_DATA. Cannot prove recover is paused."
+  fi
   if [[ ! -d "$TRANSCRIPTS" ]]; then
     refuse "transcripts missing or unreadable at $TRANSCRIPTS. Cannot prove office is idle."
   fi
-  if [[ ! -r "$TRANSCRIPTS" ]]; then
-    refuse "transcripts not readable at $TRANSCRIPTS. Cannot prove office is idle."
+  if [[ ! -r "$TRANSCRIPTS" || ! -x "$TRANSCRIPTS" ]]; then
+    refuse "transcripts not readable/traversable at $TRANSCRIPTS. Cannot prove office is idle."
   fi
   local rec
   rec="$(recover_enabled || true)"

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -16,15 +16,28 @@ _script_dir() {
 }
 
 ROOT="$(cd "$(_script_dir)/.." && pwd)"
-ADAPTERS="${FLEET_ADAPTERS:-$ROOT/adapters.sh}"
-AGENT_DATA="${FLEET_AGENT_DATA:-$HOME/agent-data}"
-TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
-AUTH_FILE="${FLEET_GROK_AUTH:-$HOME/.grok/auth.json}"
-HOT_SECONDS="${FLEET_HOT_SECONDS:-15}"
-WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid}"
-COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-41943040}"
-MODEL="${FLEET_MODEL:-grok-4.6}"
-EFFORT="${FLEET_EFFORT:-medium}"
+ADAPTERS="$ROOT/adapters.sh"
+AGENT_DATA="$HOME/agent-data"
+TRANSCRIPTS="$AGENT_DATA/agent-transcripts"
+AUTH_FILE="$HOME/.grok/auth.json"
+HOT_SECONDS=15
+WATCHDOG_PIDFILE="${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid"
+COS_JSONL_WARN_BYTES=41943040
+MODEL="grok-4.6"
+EFFORT="medium"
+
+# Test harness only. Production cutover ignores these overrides.
+if [[ "${FLEET_ALLOW_TEST_OVERRIDES:-}" == "1" ]]; then
+  ADAPTERS="${FLEET_ADAPTERS:-$ADAPTERS}"
+  AGENT_DATA="${FLEET_AGENT_DATA:-$AGENT_DATA}"
+  TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
+  AUTH_FILE="${FLEET_GROK_AUTH:-$AUTH_FILE}"
+  HOT_SECONDS="${FLEET_HOT_SECONDS:-$HOT_SECONDS}"
+  WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-$WATCHDOG_PIDFILE}"
+  COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-$COS_JSONL_WARN_BYTES}"
+  MODEL="${FLEET_MODEL:-$MODEL}"
+  EFFORT="${FLEET_EFFORT:-$EFFORT}"
+fi
 
 WANT_GO=0
 OUTSIDE_CHAT=0
@@ -63,16 +76,18 @@ EOF
 }
 
 inside_sand() {
-  if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
-    return 0
-  fi
-  if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
-    return 1
+  if test_overrides_allowed; then
+    if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
+      return 0
+    fi
+    if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
+      return 1
+    fi
   fi
   local p="${PPID:-}"
   local i=0
   local cmd
-  while [[ "$i" -lt 12 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
+  while [[ "$i" -lt 32 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
     cmd=""
     if [[ -r "/proc/$p/cmdline" ]]; then
       cmd="$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null || true)"
@@ -90,26 +105,54 @@ inside_sand() {
   return 1
 }
 
+test_overrides_allowed() {
+  [[ "${FLEET_ALLOW_TEST_OVERRIDES:-}" == "1" ]]
+}
+
+# 0 = enabled, 1 = disabled, 2 = unreadable/invalid (caller must refuse on cutover)
 json_enabled() {
-  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get("enabled") else 1)' "$1"
+  python3 -c '
+import json,sys
+try:
+    d=json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+sys.exit(0 if d.get("enabled") else 1)
+' "$1"
 }
 
 recover_enabled() {
-  local f
-  if [[ -n "${FLEET_RECOVER_JSON:-}" && -f "${FLEET_RECOVER_JSON}" ]]; then
-    if json_enabled "$FLEET_RECOVER_JSON"; then
+  local f rc
+  if test_overrides_allowed && [[ -n "${FLEET_RECOVER_JSON:-}" ]]; then
+    if [[ ! -f "${FLEET_RECOVER_JSON}" ]]; then
+      return 1
+    fi
+    json_enabled "$FLEET_RECOVER_JSON"
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
       printf '%s\n' "$FLEET_RECOVER_JSON"
+      return 0
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      printf 'INVALID:%s\n' "$FLEET_RECOVER_JSON"
       return 0
     fi
     return 1
   fi
   if [[ ! -d "$AGENT_DATA" ]]; then
+    # Missing agent-data is handled by enforce_office_state; here treat as no recover.
     return 1
   fi
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
-    if json_enabled "$f"; then
+    json_enabled "$f"
+    rc=$?
+    if [[ "$rc" -eq 0 ]]; then
       printf '%s\n' "$f"
+      return 0
+    fi
+    if [[ "$rc" -eq 2 ]]; then
+      printf 'INVALID:%s\n' "$f"
       return 0
     fi
   done < <(find "$AGENT_DATA" -path '*/automations/grok-session-recover/automation.json' 2>/dev/null || true)
@@ -131,12 +174,30 @@ hot_jsonls() {
   find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
 }
 
-# jsonl touched at or after cutover start (preflight race)
+# jsonl mtime >= cutover start (at or after). find -newermt is strictly after.
 mutated_since_t0() {
   if [[ -z "${CUTOVER_T0:-}" || ! -d "$TRANSCRIPTS" ]]; then
     return 0
   fi
-  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "@${CUTOVER_T0}" 2>/dev/null || true
+  python3 -c '
+import os,sys
+root,t0=sys.argv[1],int(sys.argv[2])
+hits=[]
+for dirpath,_,files in os.walk(root):
+    for name in files:
+        if not name.endswith(".jsonl"):
+            continue
+        path=os.path.join(dirpath,name)
+        try:
+            m=int(os.path.getmtime(path))
+        except OSError:
+            hits.append(path+":UNREADABLE")
+            continue
+        if m>=t0:
+            hits.append(path)
+for h in sorted(hits):
+    print(h)
+' "$TRANSCRIPTS" "$CUTOVER_T0" 2>/dev/null || true
 }
 
 jsonl_table() {
@@ -220,9 +281,21 @@ enforce_gates() {
   if inside_sand; then
     refuse "running under sand-host. Run me from tmux or a box shell, not CoS."
   fi
+  if [[ ! -d "$AGENT_DATA" ]]; then
+    refuse "agent-data missing or unreadable at $AGENT_DATA. Cannot prove recover is paused."
+  fi
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    refuse "transcripts missing or unreadable at $TRANSCRIPTS. Cannot prove office is idle."
+  fi
+  if [[ ! -r "$TRANSCRIPTS" ]]; then
+    refuse "transcripts not readable at $TRANSCRIPTS. Cannot prove office is idle."
+  fi
   local rec
   rec="$(recover_enabled || true)"
   if [[ -n "${rec:-}" ]]; then
+    if [[ "$rec" == INVALID:* ]]; then
+      refuse "Grok-session recover JSON unreadable/invalid (${rec#INVALID:}). Fix or remove it; do not guess."
+    fi
     refuse "Grok-session recover is enabled ($rec). Leave it paused."
   fi
   if watchdog_running; then
@@ -239,7 +312,7 @@ enforce_gates() {
   local mutated
   mutated="$(mutated_since_t0)"
   if [[ -n "$mutated" ]]; then
-    refuse "office jsonl mutated during preflight. Idle and re-run. Changed:"$'\n'"$mutated"
+    refuse "office jsonl mutated at or after cutover start. Idle and re-run. Changed:"$'\n'"$mutated"
   fi
 }
 
@@ -279,6 +352,12 @@ main() {
     exit 0
   fi
   CUTOVER_T0="${FLEET_CUTOVER_T0:-$(date +%s)}"
+  if ! test_overrides_allowed; then
+    unset FLEET_CUTOVER_T0 2>/dev/null || true
+    CUTOVER_T0="$(date +%s)"
+  elif [[ -n "${FLEET_CUTOVER_T0:-}" ]]; then
+    CUTOVER_T0="$FLEET_CUTOVER_T0"
+  fi
   preflight
   enforce_gates
   if [[ "$WANT_GO" -eq 1 ]]; then

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -30,6 +30,9 @@ WANT_GO=0
 OUTSIDE_CHAT=0
 MODE="cutover"
 EXIT_REFUSE=2
+# Epoch at cutover start — refuse if any jsonl mutates during slow preflight
+# (hot window alone can miss writes when preflight lasts longer than HOT_SECONDS).
+CUTOVER_T0=""
 
 log()  { printf '+ %s\n' "$*"; }
 warn() { printf '! %s\n' "$*" >&2; }
@@ -126,6 +129,14 @@ hot_jsonls() {
     return 0
   fi
   find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
+}
+
+# jsonl touched at or after cutover start (preflight race)
+mutated_since_t0() {
+  if [[ -z "${CUTOVER_T0:-}" || ! -d "$TRANSCRIPTS" ]]; then
+    return 0
+  fi
+  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "@${CUTOVER_T0}" 2>/dev/null || true
 }
 
 jsonl_table() {
@@ -225,6 +236,11 @@ enforce_gates() {
   if [[ -n "$hot" ]]; then
     refuse "office jsonl is hot (mid-turn). Idle first. Hot files:"$'\n'"$hot"
   fi
+  local mutated
+  mutated="$(mutated_since_t0)"
+  if [[ -n "$mutated" ]]; then
+    refuse "office jsonl mutated during preflight. Idle and re-run. Changed:"$'\n'"$mutated"
+  fi
 }
 
 run_go() {
@@ -262,6 +278,7 @@ main() {
     preflight
     exit 0
   fi
+  CUTOVER_T0="${FLEET_CUTOVER_T0:-$(date +%s)}"
   preflight
   enforce_gates
   if [[ "$WANT_GO" -eq 1 ]]; then

--- a/bin/fleet-heavy
+++ b/bin/fleet-heavy
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# fleet-heavy — dry-run wrapper around adapters.sh use grok-session.
+# Default is dry-run. Live needs --i-am-outside-chat AND --go.
+# Never run this from a Grok Bot chat (CoS included). Tests never call live adapters.
+set -euo pipefail
+
+_script_dir() {
+  local src="${BASH_SOURCE[0]}"
+  local dir
+  while [[ -L "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")" && pwd
+}
+
+ROOT="$(cd "$(_script_dir)/.." && pwd)"
+ADAPTERS="${FLEET_ADAPTERS:-$ROOT/adapters.sh}"
+AGENT_DATA="${FLEET_AGENT_DATA:-$HOME/agent-data}"
+TRANSCRIPTS="${FLEET_TRANSCRIPTS:-$AGENT_DATA/agent-transcripts}"
+AUTH_FILE="${FLEET_GROK_AUTH:-$HOME/.grok/auth.json}"
+HOT_SECONDS="${FLEET_HOT_SECONDS:-15}"
+WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid}"
+COS_JSONL_WARN_BYTES="${FLEET_COS_WARN_BYTES:-41943040}"
+MODEL="${FLEET_MODEL:-grok-4.6}"
+EFFORT="${FLEET_EFFORT:-medium}"
+
+WANT_GO=0
+OUTSIDE_CHAT=0
+MODE="cutover"
+EXIT_REFUSE=2
+
+log()  { printf '+ %s\n' "$*"; }
+warn() { printf '! %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+refuse() { printf 'REFUSE: %s\n' "$*" >&2; exit "$EXIT_REFUSE"; }
+
+usage() {
+  cat <<'EOF'
+fleet-heavy — office-wide SuperGrok Heavy cutover (wrapper around adapters)
+
+Default is dry-run. Does not restart the host.
+
+  fleet-heavy --i-am-outside-chat           # preflight, print the adapters command
+  fleet-heavy --i-am-outside-chat --go      # live flick. Restarts every office agent.
+  fleet-heavy status                        # preflight only
+  fleet-heavy --help
+
+Must refuse if: missing --i-am-outside-chat, running under sand-host,
+Grok-session recover is enabled, host-hook watchdog is running,
+~/.grok/auth.json missing, or any office jsonl is hot (mid-turn).
+
+Live command (after preflight):
+  adapters.sh use grok-session --model grok-4.6 --effort medium
+
+Never run from CoS. Never Sign Out of Cursor. Tests must stub adapters
+and must not pass --go against the live host.
+EOF
+}
+
+inside_sand() {
+  if [[ "${FLEET_FORCE_INSIDE:-}" == "1" ]]; then
+    return 0
+  fi
+  if [[ "${FLEET_FORCE_OUTSIDE:-}" == "1" ]]; then
+    return 1
+  fi
+  local p="${PPID:-}"
+  local i=0
+  local cmd
+  while [[ "$i" -lt 12 && -n "$p" && "$p" != "0" && "$p" != "1" ]]; do
+    cmd=""
+    if [[ -r "/proc/$p/cmdline" ]]; then
+      cmd="$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null || true)"
+    fi
+    if [[ "$cmd" == *host-main.cjs* || "$cmd" == *sand-host* ]]; then
+      return 0
+    fi
+    if [[ -r "/proc/$p/status" ]]; then
+      p="$(awk '/^PPid:/{print $2}' "/proc/$p/status" 2>/dev/null || echo 1)"
+    else
+      break
+    fi
+    i=$((i + 1))
+  done
+  return 1
+}
+
+json_enabled() {
+  python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get("enabled") else 1)' "$1"
+}
+
+recover_enabled() {
+  local f
+  if [[ -n "${FLEET_RECOVER_JSON:-}" && -f "${FLEET_RECOVER_JSON}" ]]; then
+    if json_enabled "$FLEET_RECOVER_JSON"; then
+      printf '%s\n' "$FLEET_RECOVER_JSON"
+      return 0
+    fi
+    return 1
+  fi
+  if [[ ! -d "$AGENT_DATA" ]]; then
+    return 1
+  fi
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if json_enabled "$f"; then
+      printf '%s\n' "$f"
+      return 0
+    fi
+  done < <(find "$AGENT_DATA" -path '*/automations/grok-session-recover/automation.json' 2>/dev/null || true)
+  return 1
+}
+
+watchdog_running() {
+  local pid
+  [[ -f "$WATCHDOG_PIDFILE" ]] || return 1
+  pid="$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+hot_jsonls() {
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    return 0
+  fi
+  find "$TRANSCRIPTS" -name '*.jsonl' -newermt "-${HOT_SECONDS} seconds" 2>/dev/null || true
+}
+
+jsonl_table() {
+  local f size name
+  if [[ ! -d "$TRANSCRIPTS" ]]; then
+    printf '(no transcripts at %s)\n' "$TRANSCRIPTS"
+    return 0
+  fi
+  printf '%-12s %s\n' "MiB" "jsonl"
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    size="$(wc -c < "$f" | tr -d ' ')"
+    name="${f#"$TRANSCRIPTS"/}"
+    awk -v s="$size" -v n="$name" -v warn="$COS_JSONL_WARN_BYTES" 'BEGIN {
+      mib = s / 1048576
+      flag = (s > warn) ? "  WARN>40MiB" : ""
+      printf "%8.1f    %s%s\n", mib, n, flag
+    }'
+  done < <(find "$TRANSCRIPTS" -name '*.jsonl' -type f 2>/dev/null | sort)
+}
+
+adapters_status() {
+  if [[ -x "$ADAPTERS" || -f "$ADAPTERS" ]]; then
+    "$ADAPTERS" status 2>/dev/null || true
+  else
+    warn "adapters missing at $ADAPTERS"
+  fi
+}
+
+live_cmd() {
+  printf '%s use grok-session --model %s --effort %s' "$ADAPTERS" "$MODEL" "$EFFORT"
+}
+
+preflight() {
+  local rec hot
+  printf '== fleet-heavy preflight ==\n'
+  printf 'mode: %s\n' "$MODE"
+  printf 'adapters: %s\n' "$ADAPTERS"
+  printf 'auth: %s\n' "$AUTH_FILE"
+  printf 'watchdog pidfile: %s\n' "$WATCHDOG_PIDFILE"
+  printf 'transcripts: %s\n' "$TRANSCRIPTS"
+  printf '\n-- adapters status --\n'
+  adapters_status
+  printf '\n-- office jsonl --\n'
+  jsonl_table
+  printf '\n-- gates --\n'
+  if inside_sand; then
+    printf 'inside sand-host: YES\n'
+  else
+    printf 'inside sand-host: no\n'
+  fi
+  rec="$(recover_enabled || true)"
+  if [[ -n "${rec:-}" ]]; then
+    printf 'grok-session recover: ENABLED (%s)\n' "$rec"
+  else
+    printf 'grok-session recover: paused/absent\n'
+  fi
+  if watchdog_running; then
+    printf 'host-hook watchdog: RUNNING (pid %s)\n' "$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+  else
+    printf 'host-hook watchdog: down\n'
+  fi
+  if [[ -f "$AUTH_FILE" ]]; then
+    printf 'grok oauth: present\n'
+  else
+    printf 'grok oauth: MISSING\n'
+  fi
+  hot="$(hot_jsonls)"
+  if [[ -n "$hot" ]]; then
+    printf 'hot jsonl (last %ss):\n%s\n' "$HOT_SECONDS" "$hot"
+  else
+    printf 'hot jsonl: none\n'
+  fi
+  printf '\nwould run:\n  %s\n' "$(live_cmd)"
+}
+
+enforce_gates() {
+  if [[ "$OUTSIDE_CHAT" -ne 1 ]]; then
+    refuse "missing --i-am-outside-chat. Run me from tmux or a box shell, not CoS."
+  fi
+  if inside_sand; then
+    refuse "running under sand-host. Run me from tmux or a box shell, not CoS."
+  fi
+  local rec
+  rec="$(recover_enabled || true)"
+  if [[ -n "${rec:-}" ]]; then
+    refuse "Grok-session recover is enabled ($rec). Leave it paused."
+  fi
+  if watchdog_running; then
+    refuse "host-hook watchdog is running. It will auto-restart onto Heavy and fight you."
+  fi
+  if [[ ! -f "$AUTH_FILE" ]]; then
+    refuse "no grok oauth at $AUTH_FILE. Do not grok login from this wrapper. Stop and tell Ricky."
+  fi
+  local hot
+  hot="$(hot_jsonls)"
+  if [[ -n "$hot" ]]; then
+    refuse "office jsonl is hot (mid-turn). Idle first. Hot files:"$'\n'"$hot"
+  fi
+}
+
+run_go() {
+  enforce_gates
+  if [[ ! -f "$ADAPTERS" ]]; then
+    die "adapters not found: $ADAPTERS"
+  fi
+  log "live flick: $(live_cmd)"
+  "$ADAPTERS" use grok-session --model "$MODEL" --effort "$EFFORT"
+}
+
+parse_args() {
+  if [[ "${1:-}" == "status" ]]; then
+    MODE="status"
+    shift || true
+  fi
+  if [[ "${1:-}" == "help" || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --i-am-outside-chat) OUTSIDE_CHAT=1; shift ;;
+      --go) WANT_GO=1; shift ;;
+      --help|-h) usage; exit 0 ;;
+      status) MODE="status"; shift ;;
+      *) die "unknown flag: $1" ;;
+    esac
+  done
+}
+
+main() {
+  parse_args "$@"
+  if [[ "$MODE" == "status" ]]; then
+    preflight
+    exit 0
+  fi
+  preflight
+  enforce_gates
+  if [[ "$WANT_GO" -eq 1 ]]; then
+    run_go
+  else
+    log "dry-run only. Pass --go after you have read the preflight. This did not restart the host."
+  fi
+}
+
+main "$@"

--- a/bin/fleet-status
+++ b/bin/fleet-status
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec "$(cd "$(dirname "$0")" && pwd)/fleet-heavy" status "$@"

--- a/bin/grok-auth-cutover-status
+++ b/bin/grok-auth-cutover-status
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# M5 — status only: hook + oauth + watchdog pid + recover armed?
+# Never --go. Never SIGTERM. Never start the watchdog. Never enable recover.
+set -euo pipefail
+
+_script_dir() {
+  local src="${BASH_SOURCE[0]}"
+  local dir
+  while [[ -L "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")" && pwd
+}
+
+ROOT="$(cd "$(_script_dir)/.." && pwd)"
+AUTH="${GROK_AUTH_FILE:-$HOME/.grok/auth.json}"
+SAND_HOST="${SAND_HOST_DIR:-$HOME/sand-host}"
+AGENT_DATA="${HOME}/agent-data"
+WATCHDOG_PIDFILE="${HOST_HOOK_DIR:-$HOME/.local/share/grok-bot-adapters/host-hook-watchdog}/watchdog.pid"
+
+if [[ "${FLEET_ALLOW_TEST_OVERRIDES:-}" == "1" ]]; then
+  AGENT_DATA="${FLEET_AGENT_DATA:-$AGENT_DATA}"
+  WATCHDOG_PIDFILE="${FLEET_WATCHDOG_PIDFILE:-$WATCHDOG_PIDFILE}"
+  SAND_HOST="${SAND_HOST_DIR:-$SAND_HOST}"
+  AUTH="${GROK_AUTH_FILE:-$AUTH}"
+fi
+
+for arg in "$@"; do
+  case "$arg" in
+    --go|--i-am-outside-chat)
+      printf 'REFUSE: grok-auth-cutover-status never flicks. No --go.\n' >&2
+      exit 2
+      ;;
+    -h|--help|help)
+      cat <<'EOF'
+grok-auth-cutover-status — probe only (hook + oauth + watchdog + recover)
+
+Never --go. Never starts host-hook-watchdog. Never enables grok-session recover.
+If oauth is EXPIRED, exit 2. Human fix: grok login --device-auth (desktop).
+EOF
+      exit 0
+      ;;
+  esac
+done
+
+HOST_MAIN="$SAND_HOST/host-main.cjs"
+SESSION="$SAND_HOST/xai-prompt-session.cjs"
+if [[ -f "$HOST_MAIN" && -f "$SESSION" ]] && grep -q createXaiPromptSession "$HOST_MAIN" 2>/dev/null; then
+  printf 'hook: present\n'
+else
+  printf 'hook: missing\n'
+fi
+
+export GROK_AUTH_FILE="$AUTH"
+oauth_rc=0
+oauth_out="$("$ROOT/bin/grok-auth-status" 2>/dev/null)" || oauth_rc=$?
+printf 'oauth: %s\n' "$oauth_out"
+
+watchdog_running() {
+  local pid
+  [[ -f "$WATCHDOG_PIDFILE" ]] || return 1
+  pid="$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+if watchdog_running; then
+  printf 'watchdog: alive pid=%s\n' "$(tr -d '[:space:]' < "$WATCHDOG_PIDFILE")"
+else
+  printf 'watchdog: down\n'
+fi
+
+recover_state="paused"
+if [[ -d "$AGENT_DATA" ]]; then
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    if python3 - "$f" <<'PY'
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(2)
+sys.exit(0 if data.get("enabled") is True else 1)
+PY
+    then
+      recover_state="enabled"
+      break
+    fi
+  done < <(find "$AGENT_DATA" -path '*/automations/grok-session-recover/automation.json' 2>/dev/null || true)
+fi
+printf 'recover: %s\n' "$recover_state"
+
+if [[ "$oauth_rc" -eq 2 ]]; then
+  exit 2
+fi
+exit 0

--- a/bin/grok-auth-status
+++ b/bin/grok-auth-status
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# M1 — probe ~/.grok/auth.json. Never prints tokens. File script (no pasted python).
+# exit 0 ok, 1 soon (<2h), 2 expired/missing
+set -euo pipefail
+
+_script_dir() {
+  local src="${BASH_SOURCE[0]}"
+  local dir
+  while [[ -L "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")" && pwd
+}
+
+ROOT="$(cd "$(_script_dir)/.." && pwd)"
+AUTH="${GROK_AUTH_FILE:-$HOME/.grok/auth.json}"
+exec python3 "$ROOT/scripts/token-expired.py" --probe "$AUTH"

--- a/docs/AGENT_INFERENCE_POLICY.md
+++ b/docs/AGENT_INFERENCE_POLICY.md
@@ -34,7 +34,7 @@ grep 'sessionOptions keys' /tmp/sand-host-manual.log | tail -20
 grep '\[sand-xai\] agent=' /tmp/sand-host-manual.log | tail -20
 ```
 
-Need a real UUID in `extracted agentId=…`. If `(empty)`, CoS/Dev/Pump stay default medium. Patch `host-main` to pass `agentId` before trusting high, and before the Codex module. Unset the dump flag after.
+Need a real UUID in `extracted agentId=…`. Live slice-0 (1 Sep) proved `sessionOptions` has **no** `agentId` key. Empty identity **refuses the per-agent overlay** (fleet default medium, never high). The hook now also passes `hostOptions` (`options2`) and dumps those keys. If that is also empty, overlay cannot SHIP until host-main exposes a UUID. Unset the dump flag after.
 
 ## Install on the box (desktop terminal)
 

--- a/docs/AGENT_INFERENCE_POLICY.md
+++ b/docs/AGENT_INFERENCE_POLICY.md
@@ -1,26 +1,40 @@
 # Agent inference policy (effort matrix + optional per-agent provider)
 
-**Status:** overlay on Heavy. Design: `kb/.../DESIGN-per-agent-effort-router-2026-08-31.md`. GO packet 31 Aug wins on conflicts.
+**Status:** overlay on Heavy. Ricky ruling 1 Sep 2026: this slice is **effort only**. Next module is per-agent **model** (Pump → Codex as the proof).
+
+## This slice (effort)
+
+| Agent | UUID | Provider | Model | Effort |
+|---|---|---|---|---|
+| CoS | `5cadd652-…` | grok-heavy | grok-4.6 | **high** |
+| Development | `7a4ecb2d-…` | grok-heavy | grok-4.6 | **high** |
+| Pump | `8ae9a103-…` | grok-heavy | grok-4.6 | **high** |
+| Finance + everyone else | — | grok-heavy | grok-4.6 | **medium** |
+
+## Next module (not this deploy)
+
+Flip Pump’s policy row to `provider: codex` / local `127.0.0.1:10531`. Codex code path stays in the hook (fail closed, no Cursor fallback). Do not enable it until slice-0 proves `agentId`.
 
 ## What it does
 
 `xai-prompt-session.cjs` reads `/home/box/sand-data/agent-inference-policy.json` (override with `SAND_AGENT_INFERENCE_POLICY`) on each session.
 
 - Missing/unreadable policy → **fail closed** (`provider=policy-missing`). Does **not** default anyone (including Pump) to grok-heavy.
-- Pump UUID without an explicit policy row → `policy-row-missing` (never silent Heavy).
+- Pump UUID without an explicit policy row → `policy-row-missing` (never silent default).
 - `extractAgentId` allowlist only: `agentId` / `agent.id` (ignores `source_agent_id` / `target_agent_id`).
 - Unknown UUID (with policy present) → medium + WARN.
-- `provider: codex` (Pump) → `http://127.0.0.1:10531/v1` with dummy Bearer `openai-oauth`. **Fail closed** if `~/.codex/auth.json` missing or proxy down — no Grok fallback, no Cursor fallback.
+- `provider: codex` (next module) → `http://127.0.0.1:10531/v1` with dummy Bearer `openai-oauth`. **Fail closed** if `~/.codex/auth.json` missing or proxy down — no Grok fallback, no Cursor fallback.
 - Hook install (`ensure-xai-inference.sh`) **rethrows** on create failure (no Cursor catch).
+- Policy reads into **locals**. Never write `SAND_XAI_*` into `process.env`.
 
-**Before Pump GO — slice 0 (log-only):** set `SAND_XAI_DUMP_SESSION_KEYS=1` in `xai-inference.env` (or the host env), restart once, ping CoS and Pump, then:
+**Before trusting high (or later Pump→Codex) — slice 0 (log-only):** set `SAND_XAI_DUMP_SESSION_KEYS=1` in `xai-inference.env` (or the host env), restart once, ping CoS and Pump, then:
 
 ```bash
 grep 'sessionOptions keys' /tmp/sand-host-manual.log | tail -20
 grep '\[sand-xai\] agent=' /tmp/sand-host-manual.log | tail -20
 ```
 
-Need a real UUID in `extracted agentId=…`. If `(empty)`, patch `host-main` to pass `agentId` before enabling Pump. Unset the dump flag after.
+Need a real UUID in `extracted agentId=…`. If `(empty)`, CoS/Dev/Pump stay default medium. Patch `host-main` to pass `agentId` before trusting high, and before the Codex module. Unset the dump flag after.
 
 ## Install on the box (desktop terminal)
 
@@ -41,10 +55,10 @@ After first deploy, **policy JSON edits do not need restart** (mtime cache).
 
 ## Smoke
 
-1. Finance short ping → log `effort=low provider=grok-heavy`
+1. Finance short ping → log `effort=medium provider=grok-heavy`
 2. CoS one line → `effort=high`
 3. Development one line → `effort=high`
-4. Pump (after `codex login --device-auth` + `adapters start openai-oauth`) → `provider=codex`
+4. Pump one line → `effort=high provider=grok-heavy` (not Codex yet)
 
 ```bash
 grep '\[sand-xai\] agent=' /tmp/sand-host-manual.log | tail -20

--- a/docs/AGENT_INFERENCE_POLICY.md
+++ b/docs/AGENT_INFERENCE_POLICY.md
@@ -6,12 +6,14 @@
 
 `xai-prompt-session.cjs` reads `/home/box/sand-data/agent-inference-policy.json` (override with `SAND_AGENT_INFERENCE_POLICY`) on each session.
 
-- Keys are **agent UUIDs** (never display names).
-- Default: Heavy `grok-4.6` effort **medium**.
-- Per-agent `effort` / `provider` / `model` as locals — **never** written into `process.env` (avoids Pump poisoning CoS).
-- Unknown UUID → medium + WARN.
+- Missing/unreadable policy → **fail closed** (`provider=policy-missing`). Does **not** default anyone (including Pump) to grok-heavy.
+- Pump UUID without an explicit policy row → `policy-row-missing` (never silent Heavy).
+- `extractAgentId` allowlist only: `agentId` / `agent.id` (ignores `source_agent_id` / `target_agent_id`).
+- Unknown UUID (with policy present) → medium + WARN.
 - `provider: codex` (Pump) → `http://127.0.0.1:10531/v1` with dummy Bearer `openai-oauth`. **Fail closed** if `~/.codex/auth.json` missing or proxy down — no Grok fallback, no Cursor fallback.
 - Hook install (`ensure-xai-inference.sh`) **rethrows** on create failure (no Cursor catch).
+
+**Before Pump GO:** log-only / smoke must prove `sessionOptions` carries the real agent UUID (slice 0). Empty `agentId` → default Heavy medium for effort seats only — Pump must not rely on empty id.
 
 ## Install on the box (desktop terminal)
 

--- a/docs/AGENT_INFERENCE_POLICY.md
+++ b/docs/AGENT_INFERENCE_POLICY.md
@@ -13,7 +13,14 @@
 - `provider: codex` (Pump) → `http://127.0.0.1:10531/v1` with dummy Bearer `openai-oauth`. **Fail closed** if `~/.codex/auth.json` missing or proxy down — no Grok fallback, no Cursor fallback.
 - Hook install (`ensure-xai-inference.sh`) **rethrows** on create failure (no Cursor catch).
 
-**Before Pump GO:** log-only / smoke must prove `sessionOptions` carries the real agent UUID (slice 0). Empty `agentId` → default Heavy medium for effort seats only — Pump must not rely on empty id.
+**Before Pump GO — slice 0 (log-only):** set `SAND_XAI_DUMP_SESSION_KEYS=1` in `xai-inference.env` (or the host env), restart once, ping CoS and Pump, then:
+
+```bash
+grep 'sessionOptions keys' /tmp/sand-host-manual.log | tail -20
+grep '\[sand-xai\] agent=' /tmp/sand-host-manual.log | tail -20
+```
+
+Need a real UUID in `extracted agentId=…`. If `(empty)`, patch `host-main` to pass `agentId` before enabling Pump. Unset the dump flag after.
 
 ## Install on the box (desktop terminal)
 

--- a/docs/AGENT_INFERENCE_POLICY.md
+++ b/docs/AGENT_INFERENCE_POLICY.md
@@ -1,0 +1,50 @@
+# Agent inference policy (effort matrix + optional per-agent provider)
+
+**Status:** overlay on Heavy. Design: `kb/.../DESIGN-per-agent-effort-router-2026-08-31.md`. GO packet 31 Aug wins on conflicts.
+
+## What it does
+
+`xai-prompt-session.cjs` reads `/home/box/sand-data/agent-inference-policy.json` (override with `SAND_AGENT_INFERENCE_POLICY`) on each session.
+
+- Keys are **agent UUIDs** (never display names).
+- Default: Heavy `grok-4.6` effort **medium**.
+- Per-agent `effort` / `provider` / `model` as locals — **never** written into `process.env` (avoids Pump poisoning CoS).
+- Unknown UUID → medium + WARN.
+- `provider: codex` (Pump) → `http://127.0.0.1:10531/v1` with dummy Bearer `openai-oauth`. **Fail closed** if `~/.codex/auth.json` missing or proxy down — no Grok fallback, no Cursor fallback.
+- Hook install (`ensure-xai-inference.sh`) **rethrows** on create failure (no Cursor catch).
+
+## Install on the box (desktop terminal)
+
+```bash
+cp /home/box/grok-bot-setup/examples/agent-inference-policy.json \
+  /home/box/sand-data/agent-inference-policy.json
+
+# Deploy updated module + fail-closed hook (one restart — Node require cache)
+cp /home/box/grok-bot-setup/xai-prompt-session.cjs /home/box/sand-host/xai-prompt-session.cjs
+# Re-run patch only if hook still has Cursor fallback:
+#   bash /home/box/grok-bot-setup/scripts/ensure-xai-inference.sh
+# Then ONE host restart from desktop terminal, e.g.:
+#   /home/box/grok-bot-setup/adapters.sh restart-host
+# (Only after Ricky GO for restart. Not from CoS.)
+```
+
+After first deploy, **policy JSON edits do not need restart** (mtime cache).
+
+## Smoke
+
+1. Finance short ping → log `effort=low provider=grok-heavy`
+2. CoS one line → `effort=high`
+3. Development one line → `effort=high`
+4. Pump (after `codex login --device-auth` + `adapters start openai-oauth`) → `provider=codex`
+
+```bash
+grep '\[sand-xai\] agent=' /tmp/sand-host-manual.log | tail -20
+```
+
+## Tests
+
+```bash
+bash ./scripts/test-agent-inference-policy.sh
+```
+
+Never points at live adapters / `--go`.

--- a/docs/BOX-DESKTOP-CURSOR-FLICK.txt
+++ b/docs/BOX-DESKTOP-CURSOR-FLICK.txt
@@ -1,0 +1,11 @@
+Desktop terminal on box@cursor ONLY. Not CoS chat. Not CoS Shell.
+
+PATH="$HOME/.local/bin:$HOME/.grok/bin:$PATH"
+
+/home/box/grok-bot-setup/adapters.sh use cursor
+
+/home/box/grok-bot-setup/adapters.sh status
+
+Want: SAND_INFERENCE_PROVIDER=cursor and sand-host :1340 UP
+Do not adapters recover. Do not unpause Pump. Do not Sign Out of Cursor.
+Hard-refresh Grok Bot if UI says Reconnecting.

--- a/docs/BOX-DESKTOP-HOOK-UPGRADE.txt
+++ b/docs/BOX-DESKTOP-HOOK-UPGRADE.txt
@@ -1,0 +1,16 @@
+Open this file as RAW text. Copy from the browser, not from chat.
+
+On box@cursor desktop terminal, run these four lines (type if paste still dies):
+
+cd /home/box/grok-bot-setup
+
+git fetch https://github.com/BlockedPath/grok-bot-setup.git refs/pull/5/head
+
+git checkout FETCH_HEAD -- scripts/box-desktop-hook-upgrade.sh
+
+bash scripts/box-desktop-hook-upgrade.sh
+
+Want: upgraded hook to pass hostOptions
+Then hard-refresh Grok Bot, ping CoS, grep sand-xai /tmp/sand-host-manual.log
+Comment hostOptions keys on https://github.com/BlockedPath/grok-bot-setup/pull/5
+No Pump Codex. No CoS-chat restart.

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -98,7 +98,7 @@ Applies to `fleet-heavy` cutover (with or without `--go`), **not** to `fleet-hea
 
 - Missing `--i-am-outside-chat`
 - Parent walk finds `host-main.cjs` / `sand-host` (test-only `FLEET_FORCE_INSIDE=1` requires `FLEET_ALLOW_TEST_OVERRIDES=1`)
-- `agent-data` or transcripts dir missing/unreadable (cannot prove idle/recover paused)
+- `agent-data` or transcripts dir missing/unreadable/non-traversable (cannot prove idle/recover paused)
 - `Grok-session recover` is enabled, or its JSON is unreadable/invalid
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -1,0 +1,183 @@
+# Grok Heavy fleet cutover
+
+**Date:** 31 Aug 2026
+**Status:** story + dry-run CLI on this PR. No live switch. Merge/deploy later GO.
+**Owner:** CoS opened this PR via the VPS `GITHUB_TOKEN`. Terra QAs. tmux Grok is not briefed until Terra SHIPs. Ricky GOs the first flick from a non-chat shell.
+
+This is how we move every office Grok Bot agent off the Cursor meter onto SuperGrok Heavy when the weekly Grok Bot cap is gone, without repeating the hours-long crash.
+
+---
+
+## 1. What we are switching
+
+Not a per-agent toggle. Not the in-app Plan screen. Not Sign Out.
+
+One shared host on Grok Bot's computer runs every office agent. Completions today go to Cursor (`SAND_INFERENCE_PROVIDER=cursor`). The UI can still show `grok-4.6`. That does not mean Heavy.
+
+Heavy means:
+
+1. Patch `host-main.cjs` so sessions use `createXaiPromptSession`
+2. Write `~/sand-data/xai-inference.env` with `SAND_INFERENCE_PROVIDER=xai`
+3. Restart `host-main.cjs`
+
+Auth stays `~/.grok/auth.json` (already present). Cursor stays signed in. There is no in-app "change to Grok" switch. Signing out of Cursor deletes the Cursor account. Never do that.
+
+The adapters command that already exists:
+
+```bash
+PATH="$HOME/.local/bin:$HOME/.grok/bin:$PATH"
+/home/box/grok-bot-setup/adapters.sh use grok-session --model grok-4.6 --effort medium
+```
+
+`--effort medium` is the multi-agent setting. Default without the flag is `high`.
+
+This PR does **not** replace that command. It wraps it so a CoS turn cannot SIGTERM the host.
+
+Back to Cursor (documented, never from CoS, not as part of this PR's tests):
+
+```bash
+/home/box/grok-bot-setup/adapters.sh use cursor
+```
+
+Both restart the host unless `--no-restart`. `--no-restart` only writes files. A later restart is still required.
+
+---
+
+## 2. Blast radius
+
+Restart kills `host-main.cjs` for **every** Grok Bot agent on this computer: CoS, Development, Diagnostics, Back Market, Pump, Alex, Inbox, Growth, Workshop, Xero, Process, Restructuring, Finance, plus unused New Agent / New Bot rows.
+
+Gateway token can change. Desktop shows **Reconnecting**. Hard-refresh Grok Bot if it sticks.
+
+Shop Hermes, Telegram, Slack bots, and VPS tmux seats are not this host. They keep running.
+
+---
+
+## 3. Why last time crashed
+
+**What we did:** flipped Heavy from **inside the CoS chat**.
+
+**What happened:** chats dead for hours. Ricky duplicated CoS and ran a second Chief of Staff until the original came back.
+
+**Measured sizes (31 Aug), not a guess:**
+
+| Store | Size |
+|---|---|
+| CoS jsonl | **56.5 MiB**, 34,716 lines |
+| CoS conversation-blobs.db | **213 MiB** |
+| CoS agent folder | **248 MiB** |
+| Development jsonl | **47.4 MiB** |
+| Nothing is 400 MB | 400 MB was high. jsonl is now past 40. |
+
+**Mechanism:**
+
+1. CoS is mid-turn on the same process the switch SIGTERMs.
+2. Host restarts and reloads the swollen CoS transcript plus 213 MiB of blobs.
+3. Heavy path then tries to POST converted history to `cli-chat-proxy.grok.com` (300s timeout), then trims to 400k chars. Trim is too late.
+4. Gateway token changes. Every agent shows Reconnecting.
+5. Overnight Cursor host wipes also drop the Heavy hook. The recover routine that auto-`adapters recover`s is **paused on purpose**. Leave it paused during any Cursor-meter week.
+
+**Rule that stands:** never switch Heavy from inside the CoS chat. Duplicate-chat is crash recovery, not a procedure.
+
+---
+
+## 4. The flick switch in this PR
+
+Wrapper, not a new inference stack.
+
+```
+bin/fleet-heavy
+bin/fleet-status
+```
+
+VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: Ricky (or a non-chat shell on Grok Bot's computer) runs the command.
+
+### 4.1 Must refuse (exit 2)
+
+- Missing `--i-am-outside-chat`
+- Parent walk finds `host-main.cjs` / `sand-host` (or `FLEET_FORCE_INSIDE=1`)
+- `Grok-session recover` is enabled
+- Host-hook watchdog is running
+- `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
+- Any office jsonl is hot in the last N seconds (mid-turn)
+
+### 4.2 Default is dry-run
+
+Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart.
+
+### 4.3 Live needs both flags
+
+```bash
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat --go
+```
+
+That is the only path that calls:
+
+`adapters.sh use grok-session --model grok-4.6 --effort medium`
+
+### 4.4 Tests
+
+`scripts/test-fleet-heavy.sh` uses a stub `adapters` binary. It may pass `--go` against the stub. It must never point `FLEET_ADAPTERS` at the live `adapters.sh` on this host.
+
+### 4.5 Pause meaning
+
+There is no official "pause all Grok Bot agents" CLI. Pause = every office agent idle (no streaming), recover off, watchdog off. Do not start a CoS turn "to pause people". Idle is enough.
+
+---
+
+## 5. After 8 Sep 2026
+
+Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen so Ultra returns at $0. Linking does not stack extra Ultra. That is billing. It is not this host patch. Do both: plan link **and** grok-session host, or you can have a paid Heavy plan while completions still hit Cursor.
+
+---
+
+## 6. Critique of this plan
+
+**What is solid**
+
+- Uses the adapters path that already worked on 23 Aug.
+- Moves the kill out of CoS.
+- Names the real size (56.5 MiB jsonl, not 400 MB).
+- Keeps Cursor login and Grok oauth.
+- `--effort medium` for a 15-agent host.
+- Tests never restart the live host.
+
+**What is still weak**
+
+- Restart still reloads the 56.5 MiB CoS jsonl. External flick avoids *self-kill*, not *fat-chat reload*. First smoke is a **small** agent (Finance), not CoS. CoS last.
+- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can start between check and SIGTERM. `--go` window is short; fail closed if any jsonl mutates during preflight.
+- VPS tmux cannot yet press the button on this host. First ship is local CLI plus a printed command. Remote SSH/bridge is a later GO.
+- Overnight Cursor host wipes will drop the hook again. After we are on Heavy, the paused recover job / watchdog need a **separate** GO.
+- Fat transcripts are the underlying disease. This switch does not compact CoS. Do not auto-trim jsonl in the wrapper.
+
+**What we will not do**
+
+- Flip from CoS.
+- `adapters use cursor` as an undo from CoS.
+- Delete or Sign Out Cursor.
+- Delete CoS to "make the file smaller".
+- Install a second CoS as the happy path.
+- Gas Town / Kilroy / HQ as the switcher.
+- Brief tmux:grok until Terra SHIPs this PR.
+
+---
+
+## 7. Build order
+
+1. This PR (story + `bin/fleet-heavy` + smashable tests).
+2. Terra QA: dry-run only on the live host. No `use grok-session` until Ricky GO.
+3. After Terra SHIP, discuss whether tmux:grok should own later work (remote trigger). Not before.
+4. Ricky GO from a non-CoS shell: `fleet-heavy --i-am-outside-chat --go`
+5. Smoke Finance (tiny chat), then Development, CoS last.
+6. Later GO: remote trigger from VPS tmux, and whether to re-arm recover/watchdog.
+
+---
+
+## 8. First command (after Terra, after GO, not now)
+
+```bash
+# on Grok Bot's computer, not in CoS, not on the VPS
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat
+# read the preflight
+/home/box/grok-bot-setup/bin/fleet-heavy --i-am-outside-chat --go
+```

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -2,7 +2,7 @@
 
 **Date:** 31 Aug 2026
 **Status:** story + dry-run CLI on this PR. No live switch. Merge/deploy later GO.
-**Owner:** CoS opened this PR via the VPS `GITHUB_TOKEN`. Terra QAs. tmux Grok is not briefed until Terra SHIPs. Ricky GOs the first flick from a non-chat shell.
+**Owner:** Opened as `panrix:feat/fleet-heavy` → BlockedPath PR #3 via VPS `gh` (panrix). Do not use the dead `GITHUB_TOKEN` PAT. Terra QAs. Ricky GOs the first flick from a non-chat shell on Grok Bot's computer.
 
 This is how we move every office Grok Bot agent off the Cursor meter onto SuperGrok Heavy when the weekly Grok Bot cap is gone, without repeating the hours-long crash.
 
@@ -100,6 +100,7 @@ VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: R
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
 - Any office jsonl is hot in the last N seconds (mid-turn)
+- Any office jsonl mutates at or after cutover start (preflight race; covers the case where preflight lasts longer than the hot window)
 
 ### 4.2 Default is dry-run
 
@@ -145,7 +146,7 @@ Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen 
 **What is still weak**
 
 - Restart still reloads the 56.5 MiB CoS jsonl. External flick avoids *self-kill*, not *fat-chat reload*. First smoke is a **small** agent (Finance), not CoS. CoS last.
-- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can start between check and SIGTERM. `--go` window is short; fail closed if any jsonl mutates during preflight.
+- No real pause API. "Idle" is a jsonl mtime heuristic. A turn can still start between the final gate and SIGTERM. The wrapper also refuses if any jsonl mutates after cutover start (covers slow preflight vs short hot window). Residual race after the last check remains.
 - VPS tmux cannot yet press the button on this host. First ship is local CLI plus a printed command. Remote SSH/bridge is a later GO.
 - Overnight Cursor host wipes will drop the hook again. After we are on Heavy, the paused recover job / watchdog need a **separate** GO.
 - Fat transcripts are the underlying disease. This switch does not compact CoS. Do not auto-trim jsonl in the wrapper.
@@ -158,7 +159,7 @@ Cursor Ultra ends 8 September 2026. Then link Heavy on the Grok Bot Plan screen 
 - Delete CoS to "make the file smaller".
 - Install a second CoS as the happy path.
 - Gas Town / Kilroy / HQ as the switcher.
-- Brief tmux:grok until Terra SHIPs this PR.
+- Live flick / remote bridge / re-arm recover-watchdog without Ricky GO.
 
 ---
 

--- a/docs/FLEET_HEAVY_CUTOVER.md
+++ b/docs/FLEET_HEAVY_CUTOVER.md
@@ -92,19 +92,24 @@ bin/fleet-status
 
 VPS tmux cannot SIGTERM this host unless we add a later bridge. First version: Ricky (or a non-chat shell on Grok Bot's computer) runs the command.
 
-### 4.1 Must refuse (exit 2)
+### 4.1 Must refuse on cutover path (exit 2)
+
+Applies to `fleet-heavy` cutover (with or without `--go`), **not** to `fleet-heavy status` / `fleet-status` (those are ungated preflight printers).
 
 - Missing `--i-am-outside-chat`
-- Parent walk finds `host-main.cjs` / `sand-host` (or `FLEET_FORCE_INSIDE=1`)
-- `Grok-session recover` is enabled
+- Parent walk finds `host-main.cjs` / `sand-host` (test-only `FLEET_FORCE_INSIDE=1` requires `FLEET_ALLOW_TEST_OVERRIDES=1`)
+- `agent-data` or transcripts dir missing/unreadable (cannot prove idle/recover paused)
+- `Grok-session recover` is enabled, or its JSON is unreadable/invalid
 - Host-hook watchdog is running
 - `~/.grok/auth.json` is missing. Do not `grok login` from the wrapper.
 - Any office jsonl is hot in the last N seconds (mid-turn)
-- Any office jsonl mutates at or after cutover start (preflight race; covers the case where preflight lasts longer than the hot window)
+- Any office jsonl mtime is **at or after** cutover start (preflight race)
+
+Test harness overrides (`FLEET_ADAPTERS`, `FLEET_FORCE_*`, path/auth stubs, etc.) are ignored unless `FLEET_ALLOW_TEST_OVERRIDES=1`.
 
 ### 4.2 Default is dry-run
 
-Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart.
+Prints `adapters status`, a jsonl size table (warn if > 40 MiB), gate results, and the adapters command that **would** run. Does not call `adapters use`. Does not restart. Note: `adapters status` may chmod the CLIProxy binary executable as a side effect of that existing command — dry-run is not a pure no-op filesystem-wise, but it does not switch inference or restart the host.
 
 ### 4.3 Live needs both flags
 

--- a/docs/GROK_AUTH_KEEPALIVE.md
+++ b/docs/GROK_AUTH_KEEPALIVE.md
@@ -1,0 +1,58 @@
+# Grok OAuth keepalive (probe / refresh attempt / fail-closed expired key)
+
+**Status:** implementation on the policy bench (`feat/agent-inference-policy` / BlockedPath #4). **Not live.** No `--go`. Recover stays paused. Watchdog stays dead.
+
+Cites: BlockedPath #3 (fleet-heavy), BlockedPath #4 (policy/models), panrix/grok-bot-setup#1 (docs packet).
+
+Overnight 31 Aug / 1 Sep: host `/health` 200, `~/.grok/auth.json` access `key` expired. Hook sent the dead key until a human ran `grok login --device-auth`.
+
+## Two-door rule (hook vs token)
+
+| Door | Symptom | Tool | Who |
+|---|---|---|---|
+| Hook missing / Cursor wipe | `createXaiPromptSession` gone from host-main | `adapters.sh recover` / `fleet-heavy --go` | Ricky, desktop terminal. **Paused.** |
+| Token dead / health 200 | M1 `status=EXPIRED` | M1 probe, optional M2, else human device-auth | CoS pings; human clicks the browser |
+
+Do not weld them. Do not start `host-hook-watchdog.sh` from the oauth path (it `restart-host` / SIGTERM'd the office). Do not enable grok-session recover from this routine. Policy overlay (who gets which model/effort) is a third knob and only works if oauth is alive **and** `agentId` is present.
+
+## Modules
+
+- **M1** `bin/grok-auth-status` — probe. Prints `exists`, `has_key`, `expires_at`, `seconds_left`, `status=ok|soon|EXPIRED`. Never prints `key`, `refresh_token`, or email. `soon` = under 2 hours (`SOON_SECONDS=7200`). Exit 0 ok, 1 soon, 2 expired/missing. Calls `scripts/token-expired.py --probe`.
+- **M2** `scripts/refresh-grok-if-expired.sh` — if ok: print `skip` and exit 0. If soon or expired: run `grok models` (non-interactive), re-probe. If still expired: print `refresh-failed` and exit 3. Never `grok login`. Never delete `auth.json`. Unproven that `grok models` rotates `expires_at` — stub both outcomes in tests.
+- **M3** `xai-prompt-session.cjs` — if `expires_at` is in the past, do **not** send the dead key. `grokSessionToken()` returns empty; `resolveAuth()` throws `GROK_AUTH_EXPIRED` (`expires_at=… seconds_left=…`, no token). Same file as the #4 policy overlay.
+- **M4** this file — CoS recipe below.
+- **M5** `bin/grok-auth-cutover-status` — hook present? M1 result? watchdog pid alive? recover armed? Exit 2 if oauth expired. Never `--go`. Never SIGTERM.
+
+## CoS recipe (ping-only)
+
+1. Run M1 (`bin/grok-auth-status`).
+2. Quiet if `status=ok`.
+3. If `soon` or `EXPIRED`, ping Ricky with the expiry timestamp and the one desktop command:
+
+```
+/home/box/.grok/bin/grok login --device-auth
+```
+
+Do not call `adapters.sh recover`, `restart-host`, or start the host-hook watchdog from this routine.
+
+Weekly Cursor → Heavy (desktop terminal, not chat):
+
+```
+adapters.sh recover          # hook only — still needs Ricky GO if it restarts host
+bin/grok-auth-status         # probe
+# if EXPIRED: grok login --device-auth  (human)
+# if ok: done
+```
+
+## Tests
+
+```
+bash ./scripts/test-grok-auth-keepalive.sh
+bash ./scripts/test-agent-inference-policy.sh
+```
+
+Stub fixtures only. No live `auth.x.ai`. No `--go`. No host restart.
+
+## Still open (inherited from #4 — do not skip)
+
+Empty `agentId` still resolves default Heavy medium. Before Pump GO, log-only slice 0: `SAND_XAI_DUMP_SESSION_KEYS=1` dumps `sessionOptions` **keys only** (no bodies). If the live host does not pass `agentId`, Pump cannot be fenced.

--- a/docs/GROK_AUTH_KEEPALIVE.md
+++ b/docs/GROK_AUTH_KEEPALIVE.md
@@ -55,4 +55,4 @@ Stub fixtures only. No live `auth.x.ai`. No `--go`. No host restart.
 
 ## Still open (inherited from #4 — do not skip)
 
-Empty `agentId` still resolves default Heavy medium. Before Pump GO, log-only slice 0: `SAND_XAI_DUMP_SESSION_KEYS=1` dumps `sessionOptions` **keys only** (no bodies). If the live host does not pass `agentId`, Pump cannot be fenced.
+Empty `agentId` still resolves default Heavy medium. Before trusting CoS/Dev/Pump **high** (and before the later Pump→Codex module), log-only slice 0: `SAND_XAI_DUMP_SESSION_KEYS=1` dumps `sessionOptions` **keys only** (no bodies). If the live host does not pass `agentId`, those seats stay medium.

--- a/examples/agent-inference-policy.json
+++ b/examples/agent-inference-policy.json
@@ -22,12 +22,13 @@
       "label": "finance",
       "provider": "grok-heavy",
       "model": "grok-4.6",
-      "effort": "low"
+      "effort": "medium"
     },
     "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9": {
       "label": "pump",
-      "provider": "codex",
-      "model": "gpt-5.4-mini"
+      "provider": "grok-heavy",
+      "model": "grok-4.6",
+      "effort": "high"
     }
   }
 }

--- a/examples/agent-inference-policy.json
+++ b/examples/agent-inference-policy.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "default": {
+    "provider": "grok-heavy",
+    "model": "grok-4.6",
+    "effort": "medium"
+  },
+  "agents": {
+    "5cadd652-c086-4ef2-8b64-e9c466e848b8": {
+      "label": "cos",
+      "provider": "grok-heavy",
+      "model": "grok-4.6",
+      "effort": "high"
+    },
+    "7a4ecb2d-9742-493e-bffb-87deb7a722b1": {
+      "label": "development",
+      "provider": "grok-heavy",
+      "model": "grok-4.6",
+      "effort": "high"
+    },
+    "01da7977-b202-4a08-a775-834768e6150e": {
+      "label": "finance",
+      "provider": "grok-heavy",
+      "model": "grok-4.6",
+      "effort": "low"
+    },
+    "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9": {
+      "label": "pump",
+      "provider": "codex",
+      "model": "gpt-5.4-mini"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "scripts/ensure-xai-inference.sh",
     "scripts/restore-after-reset.sh",
     "scripts/bootstrap.sh",
+    "scripts/test-fleet-heavy.sh",
+    "bin/fleet-heavy",
+    "bin/fleet-status",
+    "docs/FLEET_HEAVY_CUTOVER.md",
     "examples/cliproxy-openai-compat.yaml",
     "docs/GUIDE_CUSTOM_INFERENCE.md",
     "README.md",
@@ -49,6 +53,6 @@
   "scripts": {
     "adapters": "bash ./adapters.sh",
     "prepack": "test -x adapters.sh",
-    "test": "bash -n adapters.sh && bash -n adapters && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash ./adapters.sh help >/dev/null"
+    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/test-fleet-heavy.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,10 +36,17 @@
     "scripts/test-fleet-heavy.sh",
     "scripts/test-agent-inference-policy.sh",
     "scripts/test-agent-inference-policy.js",
+    "scripts/test-grok-auth-keepalive.sh",
+    "scripts/test-grok-auth-keepalive.js",
+    "scripts/token-expired.py",
+    "scripts/refresh-grok-if-expired.sh",
     "bin/fleet-heavy",
     "bin/fleet-status",
+    "bin/grok-auth-status",
+    "bin/grok-auth-cutover-status",
     "docs/FLEET_HEAVY_CUTOVER.md",
     "docs/AGENT_INFERENCE_POLICY.md",
+    "docs/GROK_AUTH_KEEPALIVE.md",
     "examples/cliproxy-openai-compat.yaml",
     "examples/agent-inference-policy.json",
     "docs/GUIDE_CUSTOM_INFERENCE.md",
@@ -57,6 +64,6 @@
   "scripts": {
     "adapters": "bash ./adapters.sh",
     "prepack": "test -x adapters.sh",
-    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/test-fleet-heavy.sh && bash -n scripts/test-agent-inference-policy.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh && bash ./scripts/test-agent-inference-policy.sh"
+    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n bin/grok-auth-status && bash -n bin/grok-auth-cutover-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/refresh-grok-if-expired.sh && bash -n scripts/test-fleet-heavy.sh && bash -n scripts/test-agent-inference-policy.sh && bash -n scripts/test-grok-auth-keepalive.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh && bash ./scripts/test-agent-inference-policy.sh && bash ./scripts/test-grok-auth-keepalive.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,14 @@
     "scripts/restore-after-reset.sh",
     "scripts/bootstrap.sh",
     "scripts/test-fleet-heavy.sh",
+    "scripts/test-agent-inference-policy.sh",
+    "scripts/test-agent-inference-policy.js",
     "bin/fleet-heavy",
     "bin/fleet-status",
     "docs/FLEET_HEAVY_CUTOVER.md",
+    "docs/AGENT_INFERENCE_POLICY.md",
     "examples/cliproxy-openai-compat.yaml",
+    "examples/agent-inference-policy.json",
     "docs/GUIDE_CUSTOM_INFERENCE.md",
     "README.md",
     "LICENSE"
@@ -53,6 +57,6 @@
   "scripts": {
     "adapters": "bash ./adapters.sh",
     "prepack": "test -x adapters.sh",
-    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/test-fleet-heavy.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh"
+    "test": "bash -n adapters.sh && bash -n adapters && bash -n bin/fleet-heavy && bash -n bin/fleet-status && bash -n scripts/ensure-xai-inference.sh && bash -n scripts/restore-after-reset.sh && bash -n scripts/bootstrap.sh && bash -n scripts/test-fleet-heavy.sh && bash -n scripts/test-agent-inference-policy.sh && bash ./adapters.sh help >/dev/null && bash ./scripts/test-fleet-heavy.sh && bash ./scripts/test-agent-inference-policy.sh"
   }
 }

--- a/scripts/box-desktop-hook-upgrade.sh
+++ b/scripts/box-desktop-hook-upgrade.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Desktop terminal on box@cursor ONLY. Not CoS chat.
+# PR #5: copy session module, upgrade hook to pass hostOptions, restart-host once.
+# No Pump Codex. No fleet-heavy --go. Watchdog stays.
+set -euo pipefail
+SETUP=/home/box/grok-bot-setup
+cd "$SETUP"
+git fetch https://github.com/BlockedPath/grok-bot-setup.git refs/pull/5/head
+git checkout FETCH_HEAD -- xai-prompt-session.cjs scripts/ensure-xai-inference.sh
+chmod +x scripts/ensure-xai-inference.sh
+cp xai-prompt-session.cjs /home/box/sand-host/xai-prompt-session.cjs
+bash scripts/ensure-xai-inference.sh
+if ! grep -q '^SAND_XAI_DUMP_SESSION_KEYS=' /home/box/sand-data/xai-inference.env; then
+  echo SAND_XAI_DUMP_SESSION_KEYS=1 >> /home/box/sand-data/xai-inference.env
+fi
+bash "$SETUP/adapters.sh" restart-host
+echo NEXT: hard-refresh Grok Bot, ping CoS, then:
+echo grep sand-xai /tmp/sand-host-manual.log
+echo Comment hostOptions keys on GitHub PR 5

--- a/scripts/ensure-xai-inference.sh
+++ b/scripts/ensure-xai-inference.sh
@@ -85,7 +85,8 @@ hook = """      const requestedModel = resolveSandRequestedModel({
             sessionOptions
           });
         } catch (xaiErr) {
-          console.error("[sand-xai] failed to create xAI session, falling back to Cursor:", xaiErr);
+          console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);
+          throw xaiErr;
         }
       }
       const session = createCursorInferencePromptSession({"""
@@ -107,7 +108,8 @@ if needle not in text:
             sessionOptions
           });
         } catch (xaiErr) {
-          console.error("[sand-xai] failed to create xAI session, falling back to Cursor:", xaiErr);
+          console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);
+          throw xaiErr;
         }
       }
 """ + anchor_tail,

--- a/scripts/ensure-xai-inference.sh
+++ b/scripts/ensure-xai-inference.sh
@@ -53,6 +53,25 @@ backup = pathlib.Path(sys.argv[2])
 text = host_main.read_text(encoding="utf-8", errors="surrogateescape")
 
 if "createXaiPromptSession" in text:
+    old_call = """return createXaiPromptSession({
+            requestedModel,
+            onRequestId,
+            sessionOptions
+          });"""
+    new_call = """return createXaiPromptSession({
+            requestedModel,
+            onRequestId,
+            sessionOptions,
+            hostOptions: typeof options2 !== "undefined" ? options2 : undefined
+          });"""
+    if "hostOptions:" in text:
+        print("hook already present")
+        raise SystemExit(0)
+    if old_call in text:
+        text = text.replace(old_call, new_call, 1)
+        host_main.write_text(text, encoding="utf-8", errors="surrogateescape")
+        print("upgraded hook to pass hostOptions")
+        raise SystemExit(0)
     print("hook already present")
     raise SystemExit(0)
 
@@ -82,7 +101,8 @@ hook = """      const requestedModel = resolveSandRequestedModel({
           return createXaiPromptSession({
             requestedModel,
             onRequestId,
-            sessionOptions
+            sessionOptions,
+            hostOptions: typeof options2 !== "undefined" ? options2 : undefined
           });
         } catch (xaiErr) {
           console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);
@@ -105,7 +125,8 @@ if needle not in text:
           return createXaiPromptSession({
             requestedModel,
             onRequestId,
-            sessionOptions
+            sessionOptions,
+            hostOptions: typeof options2 !== "undefined" ? options2 : undefined
           });
         } catch (xaiErr) {
           console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);

--- a/scripts/patch-xai-fail-closed.sh
+++ b/scripts/patch-xai-fail-closed.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Flip createXaiPromptSession catch from Cursor fallback → fail-closed throw.
+# Safe to re-run. Does not restart the host.
+set -euo pipefail
+HOST_MAIN="${1:-${SAND_HOST_MAIN:-$HOME/sand-host/host-main.cjs}}"
+[[ -f "$HOST_MAIN" ]] || { echo "missing $HOST_MAIN" >&2; exit 1; }
+python3 - "$HOST_MAIN" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1])
+text = p.read_text(encoding="utf-8", errors="surrogateescape")
+old = 'console.error("[sand-xai] failed to create xAI session, falling back to Cursor:", xaiErr);'
+# tolerate whitespace variants already fail-closed
+if "fail-closed, no Cursor fallback" in text:
+    print("already fail-closed")
+    raise SystemExit(0)
+if old not in text:
+    # try multiline catch body: log then fall through
+    import re
+    pat = re.compile(
+        r'console\.error\(\s*"\[sand-xai\] failed to create xAI session, falling back to Cursor:"\s*,\s*xaiErr\s*\);\s*',
+        re.M,
+    )
+    if not pat.search(text):
+        print("ERROR: Cursor-fallback catch not found — inspect hook manually", file=sys.stderr)
+        raise SystemExit(2)
+    text2, n = pat.subn(
+        'console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);\n          throw xaiErr;\n',
+        text,
+        count=2,
+    )
+else:
+    text2 = text.replace(
+        old,
+        'console.error("[sand-xai] failed to create xAI session (fail-closed, no Cursor fallback):", xaiErr);\n          throw xaiErr;',
+    )
+    n = 1 if text2 != text else 0
+if text2 == text:
+    print("ERROR: no change applied", file=sys.stderr)
+    raise SystemExit(2)
+bak = p.with_suffix(p.suffix + ".bak-failclosed")
+bak.write_bytes(p.read_bytes())
+p.write_text(text2, encoding="utf-8", errors="surrogateescape")
+print(f"patched fail-closed ({n} site(s)); backup {bak}")
+PY

--- a/scripts/refresh-grok-if-expired.sh
+++ b/scripts/refresh-grok-if-expired.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# M2 — attempt a non-interactive grok CLI refresh when oauth is soon or expired.
+# Never device-auth. Never delete auth.json. Never print tokens.
+# skip (exit 0) when ok. refresh-failed (exit 3) if still expired after grok models.
+set -euo pipefail
+
+_script_dir() {
+  local src="${BASH_SOURCE[0]}"
+  local dir
+  while [[ -L "$src" ]]; do
+    dir="$(cd -P "$(dirname "$src")" && pwd)"
+    src="$(readlink "$src")"
+    [[ "$src" != /* ]] && src="$dir/$src"
+  done
+  cd -P "$(dirname "$src")" && pwd
+}
+
+ROOT="$(cd "$(_script_dir)/.." && pwd)"
+STATUS="$ROOT/bin/grok-auth-status"
+export GROK_AUTH_FILE="${GROK_AUTH_FILE:-$HOME/.grok/auth.json}"
+
+rc=0
+"$STATUS" >/dev/null || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  printf 'skip\n'
+  exit 0
+fi
+if [[ "$rc" -ne 1 && "$rc" -ne 2 ]]; then
+  printf 'refresh-failed\n'
+  exit 3
+fi
+
+if ! command -v grok >/dev/null 2>&1; then
+  printf 'refresh-failed\n'
+  exit 3
+fi
+
+# Unproven that `grok models` rotates expires_at. Capture only the exit code.
+grok models >/dev/null 2>&1 || true
+
+rc2=0
+"$STATUS" >/dev/null || rc2=$?
+if [[ "$rc2" -eq 2 ]]; then
+  printf 'refresh-failed\n'
+  exit 3
+fi
+printf 'refreshed\n'
+exit 0

--- a/scripts/test-agent-inference-policy.js
+++ b/scripts/test-agent-inference-policy.js
@@ -96,7 +96,54 @@ function check(name, fn) {
     assert.ok(r.model);
   });
 
+  await check("ignore source_agent_id / target_agent_id (allowlist only)", () => {
+    const id = mod.extractAgentId({
+      source_agent_id: COS,
+      target_agent_id: PUMP,
+      agentId: FIN,
+    });
+    assert.strictEqual(id, FIN.toLowerCase());
+    const id2 = mod.extractAgentId({
+      source_agent_id: COS,
+      target_agent_id: PUMP,
+    });
+    assert.strictEqual(id2, "");
+  });
+
+  await check("empty agentId → default medium grok-heavy (with policy)", () => {
+    const r = mod.resolveAgentInference({});
+    assert.strictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.effort, "medium");
+    assert.strictEqual(r.agentId, "");
+  });
+
+  await check("policy missing + Pump UUID must not be grok-heavy", () => {
+    process.env.SAND_AGENT_INFERENCE_POLICY = path.join(WORKDIR, "does-not-exist.json");
+    // bust cache via new path
+    const r = mod.resolveAgentInference({ agentId: PUMP });
+    assert.notStrictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.provider, "policy-missing");
+    process.env.SAND_AGENT_INFERENCE_POLICY = POLICY;
+    // reload real policy
+    mod.resolveAgentInference({ agentId: FIN });
+  });
+
+  await check("Pump UUID without policy row must not be grok-heavy", () => {
+    const stripped = JSON.parse(fs.readFileSync(POLICY, "utf8"));
+    delete stripped.agents[PUMP];
+    delete stripped.agents[PUMP.toLowerCase()];
+    const strippedPath = path.join(WORKDIR, "no-pump-row.json");
+    fs.writeFileSync(strippedPath, JSON.stringify(stripped));
+    process.env.SAND_AGENT_INFERENCE_POLICY = strippedPath;
+    const r = mod.resolveAgentInference({ agentId: PUMP });
+    assert.notStrictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.provider, "policy-row-missing");
+    process.env.SAND_AGENT_INFERENCE_POLICY = POLICY;
+    mod.resolveAgentInference({ agentId: FIN });
+  });
+
   await check("createXaiPromptSession Finance effort=low", () => {
+    process.env.SAND_AGENT_INFERENCE_POLICY = POLICY;
     const s = mod.createXaiPromptSession({
       requestedModel: { modelId: "sand-default" },
       sessionOptions: { agentId: FIN },

--- a/scripts/test-agent-inference-policy.js
+++ b/scripts/test-agent-inference-policy.js
@@ -77,9 +77,9 @@ function check(name, fn) {
     assert.strictEqual(r.effort, "high");
   });
 
-  await check("Finance → low", () => {
+  await check("Finance → medium (rest of office)", () => {
     const r = mod.resolveAgentInference({ agentId: FIN });
-    assert.strictEqual(r.effort, "low");
+    assert.strictEqual(r.effort, "medium");
     assert.strictEqual(r.provider, "grok-heavy");
   });
 
@@ -90,10 +90,11 @@ function check(name, fn) {
     assert.strictEqual(r.known, false);
   });
 
-  await check("Pump → codex (not grok-heavy)", () => {
+  await check("Pump → high grok-heavy (Codex is next module)", () => {
     const r = mod.resolveAgentInference({ agentId: PUMP });
-    assert.strictEqual(r.provider, "codex");
-    assert.ok(r.model);
+    assert.strictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.effort, "high");
+    assert.strictEqual(r.model, "grok-4.6");
   });
 
   await check("ignore source_agent_id / target_agent_id (allowlist only)", () => {
@@ -142,14 +143,23 @@ function check(name, fn) {
     mod.resolveAgentInference({ agentId: FIN });
   });
 
-  await check("createXaiPromptSession Finance effort=low", () => {
+  await check("createXaiPromptSession Finance effort=medium", () => {
     process.env.SAND_AGENT_INFERENCE_POLICY = POLICY;
     const s = mod.createXaiPromptSession({
       requestedModel: { modelId: "sand-default" },
       sessionOptions: { agentId: FIN },
     });
-    assert.strictEqual(s.inference.effort, "low");
+    assert.strictEqual(s.inference.effort, "medium");
     assert.strictEqual(s.getModelId(), "grok-4.6");
+  });
+
+  await check("createXaiPromptSession Pump effort=high", () => {
+    const s = mod.createXaiPromptSession({
+      requestedModel: { modelId: "sand-default" },
+      sessionOptions: { agentId: PUMP },
+    });
+    assert.strictEqual(s.inference.effort, "high");
+    assert.strictEqual(s.inference.provider, "grok-heavy");
   });
 
   await check("policy does not mutate SAND_XAI_REASONING_EFFORT", () => {
@@ -161,11 +171,14 @@ function check(name, fn) {
     assert.ok(!process.env.SAND_XAI_BASE_URL);
   });
 
-  await check("Codex auth missing fails closed", async () => {
-    const r = mod.resolveAgentInference({ agentId: PUMP });
+  await check("Codex provider path still fail-closed (next module)", async () => {
     let threw = false;
     try {
-      await mod.resolveSessionAuth(r);
+      await mod.resolveSessionAuth({
+        provider: "codex",
+        model: "gpt-5.4-mini",
+        agentId: PUMP,
+      });
     } catch (e) {
       threw = true;
       assert.ok(

--- a/scripts/test-agent-inference-policy.js
+++ b/scripts/test-agent-inference-policy.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * Unit tests for agent-inference-policy overlay.
+ * Never hits live host, adapters use, or --go.
+ */
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const assert = require("assert");
+
+const ROOT = path.join(__dirname, "..");
+const WORKDIR = fs.mkdtempSync(path.join(os.tmpdir(), "agent-policy-test-"));
+const POLICY = path.join(WORKDIR, "agent-inference-policy.json");
+fs.copyFileSync(path.join(ROOT, "examples/agent-inference-policy.json"), POLICY);
+
+process.env.SAND_AGENT_INFERENCE_POLICY = POLICY;
+process.env.SAND_XAI_ENV_FILE = path.join(WORKDIR, "missing.env");
+process.env.SAND_XAI_MODEL = "grok-4.6";
+process.env.SAND_XAI_REASONING_EFFORT = "medium";
+process.env.CODEX_AUTH_FILE = path.join(WORKDIR, "no-codex-auth.json");
+
+const mod = require(path.join(ROOT, "xai-prompt-session.cjs"));
+
+const COS = "5cadd652-c086-4ef2-8b64-e9c466e848b8";
+const DEV = "7a4ecb2d-9742-493e-bffb-87deb7a722b1";
+const FIN = "01da7977-b202-4a08-a775-834768e6150e";
+const PUMP = "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9";
+const UNKNOWN = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+let pass = 0;
+let fail = 0;
+
+function check(name, fn) {
+  try {
+    const r = fn();
+    if (r && typeof r.then === "function") {
+      return r
+        .then(() => {
+          console.log("ok ", name);
+          pass += 1;
+        })
+        .catch((e) => {
+          console.log("FAIL", name, e && e.message ? e.message : e);
+          fail += 1;
+        });
+    }
+    console.log("ok ", name);
+    pass += 1;
+    return Promise.resolve();
+  } catch (e) {
+    console.log("FAIL", name, e && e.message ? e.message : e);
+    fail += 1;
+    return Promise.resolve();
+  }
+}
+
+(async () => {
+  await check("extract agentId from sessionOptions.agentId", () => {
+    assert.strictEqual(mod.extractAgentId({ agentId: COS }), COS.toLowerCase());
+  });
+
+  await check("extract agentId from nested agent.id", () => {
+    assert.strictEqual(mod.extractAgentId({ agent: { id: FIN } }), FIN.toLowerCase());
+  });
+
+  await check("CoS → high grok-heavy", () => {
+    const r = mod.resolveAgentInference({ agentId: COS });
+    assert.strictEqual(r.effort, "high");
+    assert.strictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.model, "grok-4.6");
+    assert.strictEqual(r.known, true);
+  });
+
+  await check("Development → high", () => {
+    const r = mod.resolveAgentInference({ agentId: DEV });
+    assert.strictEqual(r.effort, "high");
+  });
+
+  await check("Finance → low", () => {
+    const r = mod.resolveAgentInference({ agentId: FIN });
+    assert.strictEqual(r.effort, "low");
+    assert.strictEqual(r.provider, "grok-heavy");
+  });
+
+  await check("unknown UUID → medium", () => {
+    const r = mod.resolveAgentInference({ agentId: UNKNOWN });
+    assert.strictEqual(r.effort, "medium");
+    assert.strictEqual(r.provider, "grok-heavy");
+    assert.strictEqual(r.known, false);
+  });
+
+  await check("Pump → codex (not grok-heavy)", () => {
+    const r = mod.resolveAgentInference({ agentId: PUMP });
+    assert.strictEqual(r.provider, "codex");
+    assert.ok(r.model);
+  });
+
+  await check("createXaiPromptSession Finance effort=low", () => {
+    const s = mod.createXaiPromptSession({
+      requestedModel: { modelId: "sand-default" },
+      sessionOptions: { agentId: FIN },
+    });
+    assert.strictEqual(s.inference.effort, "low");
+    assert.strictEqual(s.getModelId(), "grok-4.6");
+  });
+
+  await check("policy does not mutate SAND_XAI_REASONING_EFFORT", () => {
+    process.env.SAND_XAI_REASONING_EFFORT = "medium";
+    delete process.env.SAND_XAI_BASE_URL;
+    mod.resolveAgentInference({ agentId: COS });
+    mod.resolveAgentInference({ agentId: PUMP });
+    assert.strictEqual(process.env.SAND_XAI_REASONING_EFFORT, "medium");
+    assert.ok(!process.env.SAND_XAI_BASE_URL);
+  });
+
+  await check("Codex auth missing fails closed", async () => {
+    const r = mod.resolveAgentInference({ agentId: PUMP });
+    let threw = false;
+    try {
+      await mod.resolveSessionAuth(r);
+    } catch (e) {
+      threw = true;
+      assert.ok(
+        e.code === "CODEX_AUTH_MISSING" || /Codex/i.test(String(e.message)),
+        String(e.message)
+      );
+    }
+    assert.ok(threw);
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  try {
+    fs.rmSync(WORKDIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/scripts/test-agent-inference-policy.js
+++ b/scripts/test-agent-inference-policy.js
@@ -111,11 +111,40 @@ function check(name, fn) {
     assert.strictEqual(id2, "");
   });
 
-  await check("empty agentId → default medium grok-heavy (with policy)", () => {
+  await check("empty agentId → fleet default medium, not high (overlay refused)", () => {
     const r = mod.resolveAgentInference({});
     assert.strictEqual(r.provider, "grok-heavy");
     assert.strictEqual(r.effort, "medium");
     assert.strictEqual(r.agentId, "");
+    assert.strictEqual(r.known, false);
+  });
+
+  await check("hostOptions.agentId UUID is used", () => {
+    const r = mod.resolveAgentInference(
+      {},
+      { hostOptions: { agentId: COS } }
+    );
+    assert.strictEqual(r.agentId, COS.toLowerCase());
+    assert.strictEqual(r.effort, "high");
+    assert.strictEqual(r.known, true);
+  });
+
+  await check("hostOptions.getAgentId() UUID is used", () => {
+    const r = mod.resolveAgentInference(
+      {},
+      { hostOptions: { getAgentId: () => DEV } }
+    );
+    assert.strictEqual(r.agentId, DEV.toLowerCase());
+    assert.strictEqual(r.effort, "high");
+  });
+
+  await check("ignore source_agent_id even on hostOptions", () => {
+    const r = mod.resolveAgentInference(
+      { source_agent_id: COS },
+      { hostOptions: { source_agent_id: PUMP } }
+    );
+    assert.strictEqual(r.agentId, "");
+    assert.strictEqual(r.effort, "medium");
   });
 
   await check("policy missing + Pump UUID must not be grok-heavy", () => {

--- a/scripts/test-agent-inference-policy.sh
+++ b/scripts/test-agent-inference-policy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Wrapper: unit tests for agent-inference-policy. Never live host.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+exec node "$ROOT/scripts/test-agent-inference-policy.js"

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -103,6 +103,14 @@ assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
 touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 
+# Mutation during preflight: file newer than CUTOVER_T0 but outside the hot window.
+# Simulates a turn that started at cutover start then went idle before the final gate.
+touch -d "5 seconds ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl mutated since cutover t0" \
+  env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$(( $(date +%s) - 30 ))" \
+  "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
 : > "$FLEET_STUB_LOG"
 assert_exit 0 "dry-run succeeds" \
   "$FLEET" --i-am-outside-chat

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -67,6 +67,8 @@ echo "STUB $*"
 STUB
 chmod +x "$WORKDIR/stub-adapters" "$FLEET" "$ROOT/bin/fleet-status"
 
+# Harness overrides are gated. Without the allow flag they must be ignored.
+export FLEET_ALLOW_TEST_OVERRIDES=1
 export FLEET_FORCE_OUTSIDE=1
 export FLEET_ADAPTERS="$WORKDIR/stub-adapters"
 export FLEET_AGENT_DATA="$WORKDIR/agent-data"
@@ -83,9 +85,34 @@ assert_exit 2 "refuse without --i-am-outside-chat" \
 assert_exit 2 "refuse if inside sand-host" \
   env FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
 
+# Prod must ignore FORCE_INSIDE without the allow flag.
+# Without overrides, this VPS lacks office agent-data → refuse missing state, NOT sand-host.
+assert_exit 2 "FORCE_INSIDE ignored without allow flag" \
+  env -u FLEET_ALLOW_TEST_OVERRIDES FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
+if grep -q 'running under sand-host' /tmp/fleet-test-err; then
+  printf 'FAIL FORCE_INSIDE without allow still tripped sand gate\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  FORCE_INSIDE without allow did not trip sand gate\n'
+  PASS=$((PASS + 1))
+fi
+assert_exit 2 "allow+FORCE_INSIDE still refuses" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 \
+  "$FLEET" --i-am-outside-chat
+if ! grep -q 'running under sand-host' /tmp/fleet-test-err; then
+  printf 'FAIL allow+FORCE_INSIDE should refuse via sand gate\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  allow+FORCE_INSIDE refused via sand gate\n'
+  PASS=$((PASS + 1))
+fi
 printf '%s\n' '{"name":"Grok-session recover","enabled":true}' \
   > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
 assert_exit 2 "refuse if recover enabled" \
+  "$FLEET" --i-am-outside-chat
+printf '%s\n' 'NOT-JSON' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+assert_exit 2 "refuse if recover JSON invalid" \
   "$FLEET" --i-am-outside-chat
 printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
   > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
@@ -98,13 +125,23 @@ rm -f "$WORKDIR/watchdog/watchdog.pid"
 assert_exit 2 "refuse if no grok oauth" \
   env FLEET_GROK_AUTH="$WORKDIR/missing-auth.json" "$FLEET" --i-am-outside-chat
 
+assert_exit 2 "refuse if transcripts missing" \
+  env FLEET_TRANSCRIPTS="$WORKDIR/missing-transcripts" "$FLEET" --i-am-outside-chat
+
 touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
 touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 
-# Mutation during preflight: file newer than CUTOVER_T0 but outside the hot window.
-# Simulates a turn that started at cutover start then went idle before the final gate.
+# Equality boundary: mtime == CUTOVER_T0 must refuse (at or after).
+T0=$(( $(date +%s) - 30 ))
+touch -d "@${T0}" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl mtime equals cutover t0" \
+  env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$T0" \
+  "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
+# Strictly after T0, outside hot window.
 touch -d "5 seconds ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl mutated since cutover t0" \
   env FLEET_HOT_SECONDS=1 FLEET_CUTOVER_T0="$(( $(date +%s) - 30 ))" \

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -128,6 +128,13 @@ assert_exit 2 "refuse if no grok oauth" \
 assert_exit 2 "refuse if transcripts missing" \
   env FLEET_TRANSCRIPTS="$WORKDIR/missing-transcripts" "$FLEET" --i-am-outside-chat
 
+chmod 000 "$WORKDIR/agent-data"
+assert_exit 2 "refuse if agent-data unreadable" \
+  "$FLEET" --i-am-outside-chat
+chmod 755 "$WORKDIR/agent-data"
+# restore nested perms after parent chmod 000
+chmod -R u+rwX "$WORKDIR/agent-data" 2>/dev/null || true
+
 touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
 assert_exit 2 "refuse if jsonl hot" \
   env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat

--- a/scripts/test-fleet-heavy.sh
+++ b/scripts/test-fleet-heavy.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Smashable tests for bin/fleet-heavy. Never call live adapters or --go on the host.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FLEET="$ROOT/bin/fleet-heavy"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local want="$1"
+  local name="$2"
+  shift 2
+  local rc=0
+  "$@" >/tmp/fleet-test-out 2>/tmp/fleet-test-err || rc=$?
+  if [[ "$rc" -eq "$want" ]]; then
+    printf 'ok  %s (exit %s)\n' "$name" "$rc"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s (want %s got %s)\n' "$name" "$want" "$rc"
+    sed 's/^/  out: /' /tmp/fleet-test-out | tail -20
+    sed 's/^/  err: /' /tmp/fleet-test-err | tail -20
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_in() {
+  local needle="$1"
+  local file="$2"
+  local name="$3"
+  if grep -q -- "$needle" "$file"; then
+    printf 'FAIL %s (found %s in %s)\n' "$name" "$needle" "$file"
+    FAIL=$((FAIL + 1))
+  else
+    printf 'ok  %s\n' "$name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+WORKDIR="$(mktemp -d /tmp/fleet-heavy-test.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+mkdir -p "$WORKDIR/agent-data/agent-transcripts/tiny" \
+         "$WORKDIR/agent-data/agents/test/automations/grok-session-recover" \
+         "$WORKDIR/watchdog" \
+         "$WORKDIR/grok"
+printf '{}\n' > "$WORKDIR/grok/auth.json"
+printf 'paused chat\n' > "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+
+cat > "$WORKDIR/stub-adapters" << 'STUB'
+#!/usr/bin/env bash
+log="${FLEET_STUB_LOG:-/tmp/fleet-stub.log}"
+printf '%s\n' "$*" >> "$log"
+if [[ "${1:-}" == "status" ]]; then
+  echo "provider: cursor"
+  echo "host: up"
+  echo "grok oauth: present"
+  exit 0
+fi
+if [[ "${1:-}" == "use" ]]; then
+  echo "STUB_USE $*"
+  exit 0
+fi
+echo "STUB $*"
+STUB
+chmod +x "$WORKDIR/stub-adapters" "$FLEET" "$ROOT/bin/fleet-status"
+
+export FLEET_FORCE_OUTSIDE=1
+export FLEET_ADAPTERS="$WORKDIR/stub-adapters"
+export FLEET_AGENT_DATA="$WORKDIR/agent-data"
+export FLEET_TRANSCRIPTS="$WORKDIR/agent-data/agent-transcripts"
+export FLEET_GROK_AUTH="$WORKDIR/grok/auth.json"
+export FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid"
+export FLEET_HOT_SECONDS=15
+export FLEET_STUB_LOG="$WORKDIR/stub.log"
+: > "$FLEET_STUB_LOG"
+
+assert_exit 2 "refuse without --i-am-outside-chat" \
+  env FLEET_FORCE_OUTSIDE=1 "$FLEET"
+
+assert_exit 2 "refuse if inside sand-host" \
+  env FLEET_FORCE_OUTSIDE=0 FLEET_FORCE_INSIDE=1 "$FLEET" --i-am-outside-chat
+
+printf '%s\n' '{"name":"Grok-session recover","enabled":true}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+assert_exit 2 "refuse if recover enabled" \
+  "$FLEET" --i-am-outside-chat
+printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+
+echo "$$" > "$WORKDIR/watchdog/watchdog.pid"
+assert_exit 2 "refuse if watchdog running" \
+  "$FLEET" --i-am-outside-chat
+rm -f "$WORKDIR/watchdog/watchdog.pid"
+
+assert_exit 2 "refuse if no grok oauth" \
+  env FLEET_GROK_AUTH="$WORKDIR/missing-auth.json" "$FLEET" --i-am-outside-chat
+
+touch "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+assert_exit 2 "refuse if jsonl hot" \
+  env FLEET_HOT_SECONDS=60 "$FLEET" --i-am-outside-chat
+touch -d "10 minutes ago" "$WORKDIR/agent-data/agent-transcripts/tiny/tiny.jsonl"
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "dry-run succeeds" \
+  "$FLEET" --i-am-outside-chat
+assert_not_in "use grok-session" "$FLEET_STUB_LOG" "dry-run did not call adapters use"
+if grep -q "^status$" "$FLEET_STUB_LOG"; then
+  printf 'ok  dry-run called adapters status\n'
+  PASS=$((PASS + 1))
+else
+  printf 'FAIL dry-run should call adapters status\n'
+  FAIL=$((FAIL + 1))
+fi
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "go against stub adapters" \
+  "$FLEET" --i-am-outside-chat --go
+if grep -q "use grok-session --model grok-4.6 --effort medium" "$FLEET_STUB_LOG"; then
+  printf 'ok  go called stub with medium effort\n'
+  PASS=$((PASS + 1))
+else
+  printf 'FAIL go did not call stub use grok-session medium\n'
+  cat "$FLEET_STUB_LOG"
+  FAIL=$((FAIL + 1))
+fi
+
+if grep -q "adapters.sh" "$FLEET_STUB_LOG"; then
+  printf 'FAIL stub log mentions adapters.sh\n'
+  FAIL=$((FAIL + 1))
+else
+  printf 'ok  stub log has no live adapters.sh path\n'
+  PASS=$((PASS + 1))
+fi
+
+: > "$FLEET_STUB_LOG"
+assert_exit 0 "status without flag" \
+  "$FLEET" status
+assert_not_in "use grok-session" "$FLEET_STUB_LOG" "status did not call adapters use"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/test-grok-auth-keepalive.js
+++ b/scripts/test-grok-auth-keepalive.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * M3: expired grok auth must not return the dead key.
+ * Never hits live auth.x.ai, adapters, or --go.
+ */
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const assert = require("assert");
+
+const ROOT = path.join(__dirname, "..");
+const WORKDIR = fs.mkdtempSync(path.join(os.tmpdir(), "grok-auth-m3-"));
+const AUTH = path.join(WORKDIR, "auth.json");
+
+delete process.env.XAI_API_KEY;
+delete process.env.GROK_CODE_XAI_API_KEY;
+delete process.env.GROK_XAI_API_KEY;
+delete process.env.GROK_SESSION_TOKEN;
+process.env.GROK_AUTH_FILE = AUTH;
+process.env.SAND_XAI_ENV_FILE = path.join(WORKDIR, "missing.env");
+process.env.SAND_AGENT_INFERENCE_POLICY = path.join(ROOT, "examples/agent-inference-policy.json");
+
+const KEY = "TEST_KEY_DO_NOT_LEAK";
+const REFRESH = "TEST_REFRESH_DO_NOT_LEAK";
+const COS = "5cadd652-c086-4ef2-8b64-e9c466e848b8";
+
+function isoOffset(seconds) {
+  return new Date(Date.now() + seconds * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function writeAuth(expiresAt) {
+  fs.writeFileSync(
+    AUTH,
+    JSON.stringify({
+      "https://auth.x.ai": {
+        key: KEY,
+        refresh_token: REFRESH,
+        expires_at: expiresAt,
+        auth_mode: "oidc",
+        email: "secret@example.com",
+      },
+    })
+  );
+}
+
+const mod = require(path.join(ROOT, "xai-prompt-session.cjs"));
+
+let pass = 0;
+let fail = 0;
+
+function check(name, fn) {
+  try {
+    const r = fn();
+    if (r && typeof r.then === "function") {
+      return r
+        .then(() => {
+          console.log("ok ", name);
+          pass += 1;
+        })
+        .catch((e) => {
+          console.log("FAIL", name, e && e.message ? e.message : e);
+          fail += 1;
+        });
+    }
+    console.log("ok ", name);
+    pass += 1;
+    return Promise.resolve();
+  } catch (e) {
+    console.log("FAIL", name, e && e.message ? e.message : e);
+    fail += 1;
+    return Promise.resolve();
+  }
+}
+
+(async () => {
+  await check("exports grokSessionToken + grokAuthProbe + resolveAuth", () => {
+    assert.strictEqual(typeof mod.grokSessionToken, "function");
+    assert.strictEqual(typeof mod.grokAuthProbe, "function");
+    assert.strictEqual(typeof mod.resolveAuth, "function");
+  });
+
+  writeAuth(isoOffset(36000));
+  await check("fresh key is returned", () => {
+    const probe = mod.grokAuthProbe();
+    assert.strictEqual(probe.status, "ok");
+    assert.strictEqual(probe.has_key, true);
+    assert.strictEqual(mod.grokSessionToken(), KEY);
+    const auth = mod.resolveAuth();
+    assert.strictEqual(auth.mode, "session");
+    assert.strictEqual(auth.token, KEY);
+  });
+
+  writeAuth(isoOffset(1800));
+  await check("soon still returns key (no auto-refresh in hook)", () => {
+    const probe = mod.grokAuthProbe();
+    assert.strictEqual(probe.status, "soon");
+    assert.strictEqual(mod.grokSessionToken(), KEY);
+  });
+
+  writeAuth(isoOffset(-7200));
+  await check("expired probe does not include token fields", () => {
+    const probe = mod.grokAuthProbe();
+    assert.strictEqual(probe.status, "EXPIRED");
+    assert.ok(probe.seconds_left < 0);
+    const blob = JSON.stringify(probe);
+    assert.ok(!blob.includes(KEY), blob);
+    assert.ok(!blob.includes(REFRESH), blob);
+    assert.ok(!blob.includes("secret@example.com"), blob);
+  });
+
+  await check("expired grokSessionToken returns empty (no dead key)", () => {
+    assert.strictEqual(mod.grokSessionToken(), "");
+  });
+
+  await check("expired resolveAuth throws GROK_AUTH_EXPIRED without token", () => {
+    let threw = false;
+    try {
+      mod.resolveAuth();
+    } catch (e) {
+      threw = true;
+      assert.strictEqual(e.code, "GROK_AUTH_EXPIRED");
+      const msg = String(e.message);
+      assert.ok(/GROK_AUTH_EXPIRED/.test(msg), msg);
+      assert.ok(/expires_at=/.test(msg), msg);
+      assert.ok(/seconds_left=/.test(msg), msg);
+      assert.ok(!msg.includes(KEY), msg);
+      assert.ok(!msg.includes(REFRESH), msg);
+    }
+    assert.ok(threw);
+  });
+
+  await check("expired resolveSessionAuth throws GROK_AUTH_EXPIRED", async () => {
+    const inf = mod.resolveAgentInference({ agentId: COS });
+    assert.strictEqual(inf.provider, "grok-heavy");
+    let threw = false;
+    try {
+      await mod.resolveSessionAuth(inf);
+    } catch (e) {
+      threw = true;
+      assert.strictEqual(e.code, "GROK_AUTH_EXPIRED");
+      assert.ok(!String(e.message).includes(KEY));
+    }
+    assert.ok(threw);
+  });
+
+  console.log(`\n${pass} passed, ${fail} failed`);
+  try {
+    fs.rmSync(WORKDIR, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/scripts/test-grok-auth-keepalive.sh
+++ b/scripts/test-grok-auth-keepalive.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Smashable tests for grok oauth keepalive (M1–M5). Never live login, never --go, never restart-host.
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+WORKDIR="$(mktemp -d /tmp/grok-auth-keepalive.XXXXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+OUT_DIR="$WORKDIR/out"
+mkdir -p "$OUT_DIR" "$WORKDIR/grok" "$WORKDIR/bin" "$WORKDIR/sand-host" \
+         "$WORKDIR/agent-data/agents/test/automations/grok-session-recover" \
+         "$WORKDIR/watchdog"
+
+assert_exit() {
+  local want="$1"
+  local name="$2"
+  shift 2
+  local rc=0
+  local tag
+  tag="$(printf '%s' "$name" | tr -c 'A-Za-z0-9' '_')"
+  local stdout="$OUT_DIR/${tag}.stdout"
+  local stderr="$OUT_DIR/${tag}.stderr"
+  "$@" >"$stdout" 2>"$stderr" || rc=$?
+  if [[ "$rc" -eq "$want" ]]; then
+    printf 'ok  %s (exit %s)\n' "$name" "$rc"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s (want %s got %s)\n' "$name" "$want" "$rc"
+    sed 's/^/  out: /' "$stdout" | tail -20
+    sed 's/^/  err: /' "$stderr" | tail -20
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_grep() {
+  local file="$1"
+  local needle="$2"
+  local name="$3"
+  if grep -q -- "$needle" "$file"; then
+    printf 'ok  %s\n' "$name"
+    PASS=$((PASS + 1))
+  else
+    printf 'FAIL %s (missing %s in %s)\n' "$name" "$needle" "$file"
+    sed 's/^/  /' "$file" | tail -20
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_grep() {
+  local file="$1"
+  local needle="$2"
+  local name="$3"
+  if grep -q -- "$needle" "$file"; then
+    printf 'FAIL %s (found %s in %s)\n' "$name" "$needle" "$file"
+    sed 's/^/  /' "$file" | tail -20
+    FAIL=$((FAIL + 1))
+  else
+    printf 'ok  %s\n' "$name"
+    PASS=$((PASS + 1))
+  fi
+}
+
+write_auth() {
+  local dest="$1"
+  local expires_at="$2"
+  python3 - "$dest" "$expires_at" <<'PY'
+import json, sys
+dest, expires_at = sys.argv[1], sys.argv[2]
+obj = {
+    "https://auth.x.ai": {
+        "key": "TEST_KEY_DO_NOT_LEAK",
+        "refresh_token": "TEST_REFRESH_DO_NOT_LEAK",
+        "expires_at": expires_at,
+        "auth_mode": "oidc",
+        "email": "secret@example.com",
+    }
+}
+with open(dest, "w") as f:
+    json.dump(obj, f)
+PY
+}
+
+iso_offset() {
+  python3 - "$1" <<'PY'
+import datetime, sys
+delta = int(sys.argv[1])
+dt = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=delta)
+print(dt.replace(microsecond=0).isoformat().replace("+00:00", "Z"))
+PY
+}
+
+STATUS="$ROOT/bin/grok-auth-status"
+REFRESH="$ROOT/scripts/refresh-grok-if-expired.sh"
+CUTOVER="$ROOT/bin/grok-auth-cutover-status"
+TOKEN_PY="$ROOT/scripts/token-expired.py"
+
+export FLEET_ALLOW_TEST_OVERRIDES=1
+export GROK_AUTH_FILE="$WORKDIR/grok/auth.json"
+unset XAI_API_KEY GROK_CODE_XAI_API_KEY GROK_XAI_API_KEY GROK_SESSION_TOKEN || true
+
+# --- token-expired.py (kept module) ---
+write_auth "$GROK_AUTH_FILE" "$(iso_offset -3600)"
+assert_exit 0 "token-expired.py expired prints 1" \
+  python3 "$TOKEN_PY" "$GROK_AUTH_FILE"
+assert_grep "$OUT_DIR/token_expired_py_expired_prints_1.stdout" '^1$' "token-expired.py expired -> 1"
+
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 36000)"
+assert_exit 0 "token-expired.py ok prints 0" \
+  python3 "$TOKEN_PY" "$GROK_AUTH_FILE"
+assert_grep "$OUT_DIR/token_expired_py_ok_prints_0.stdout" '^0$' "token-expired.py ok -> 0"
+
+# --- M1 probe ---
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 36000)"
+assert_exit 0 "M1 ok exit 0" env GROK_AUTH_FILE="$GROK_AUTH_FILE" "$STATUS"
+assert_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'status=ok' "M1 ok status"
+assert_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'has_key=true' "M1 ok has_key"
+assert_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'exists=yes' "M1 ok exists"
+assert_not_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'TEST_KEY_DO_NOT_LEAK' "M1 ok does not print key"
+assert_not_grep "$OUT_DIR/M1_ok_exit_0.stderr" 'TEST_KEY_DO_NOT_LEAK' "M1 ok stderr no key"
+assert_not_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'TEST_REFRESH_DO_NOT_LEAK' "M1 ok does not print refresh"
+assert_not_grep "$OUT_DIR/M1_ok_exit_0.stdout" 'secret@example.com' "M1 ok does not print email"
+
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 1800)"
+assert_exit 1 "M1 soon exit 1" env GROK_AUTH_FILE="$GROK_AUTH_FILE" "$STATUS"
+assert_grep "$OUT_DIR/M1_soon_exit_1.stdout" 'status=soon' "M1 soon status"
+
+write_auth "$GROK_AUTH_FILE" "$(iso_offset -7200)"
+assert_exit 2 "M1 expired exit 2" env GROK_AUTH_FILE="$GROK_AUTH_FILE" "$STATUS"
+assert_grep "$OUT_DIR/M1_expired_exit_2.stdout" 'status=EXPIRED' "M1 expired status"
+assert_grep "$OUT_DIR/M1_expired_exit_2.stdout" 'seconds_left=' "M1 expired seconds_left"
+assert_not_grep "$OUT_DIR/M1_expired_exit_2.stdout" 'TEST_KEY_DO_NOT_LEAK' "M1 expired does not print key"
+
+assert_exit 2 "M1 missing file exit 2" env GROK_AUTH_FILE="$WORKDIR/missing-auth.json" "$STATUS"
+assert_grep "$OUT_DIR/M1_missing_file_exit_2.stdout" 'status=EXPIRED' "M1 missing status EXPIRED"
+assert_grep "$OUT_DIR/M1_missing_file_exit_2.stdout" 'exists=no' "M1 missing exists=no"
+
+# --- M2 refresh ---
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 36000)"
+assert_exit 0 "M2 skip when ok" env GROK_AUTH_FILE="$GROK_AUTH_FILE" "$REFRESH"
+assert_grep "$OUT_DIR/M2_skip_when_ok.stdout" 'skip' "M2 prints skip"
+
+# stub grok that rewrites expires_at into the future
+cat > "$WORKDIR/bin/grok" << 'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+auth="${GROK_AUTH_FILE:-}"
+[[ -n "$auth" && -f "$auth" ]] || exit 1
+python3 - "$auth" <<'PY'
+import datetime, json, sys
+path = sys.argv[1]
+data = json.loads(open(path).read())
+future = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=10)).replace(microsecond=0)
+iso = future.isoformat().replace("+00:00", "Z")
+for v in data.values():
+    if isinstance(v, dict) and "expires_at" in v:
+        v["expires_at"] = iso
+open(path, "w").write(json.dumps(data))
+PY
+STUB
+chmod +x "$WORKDIR/bin/grok"
+
+write_auth "$GROK_AUTH_FILE" "$(iso_offset -3600)"
+assert_exit 0 "M2 refresh stub rewrites expiry" \
+  env PATH="$WORKDIR/bin:$PATH" GROK_AUTH_FILE="$GROK_AUTH_FILE" "$REFRESH"
+assert_exit 0 "M1 ok after stub refresh" env GROK_AUTH_FILE="$GROK_AUTH_FILE" "$STATUS"
+
+# stub grok that no-ops
+cat > "$WORKDIR/bin/grok" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$WORKDIR/bin/grok"
+write_auth "$GROK_AUTH_FILE" "$(iso_offset -3600)"
+assert_exit 3 "M2 refresh-failed when grok no-ops" \
+  env PATH="$WORKDIR/bin:$PATH" GROK_AUTH_FILE="$GROK_AUTH_FILE" "$REFRESH"
+assert_grep "$OUT_DIR/M2_refresh_failed_when_grok_no_ops.stdout" 'refresh-failed' "M2 prints refresh-failed"
+
+assert_not_grep "$REFRESH" 'grok login' "M2 script does not invoke grok login"
+assert_not_grep "$REFRESH" 'rm ' "M2 script does not rm (auth.json)"
+
+# --- M3 hook fail-closed (node) ---
+assert_exit 0 "M3 node tests" node "$ROOT/scripts/test-grok-auth-keepalive.js"
+
+# --- M5 cutover status ---
+printf 'createXaiPromptSession(options)\n' > "$WORKDIR/sand-host/host-main.cjs"
+printf '// session module\n' > "$WORKDIR/sand-host/xai-prompt-session.cjs"
+printf '%s\n' '{"name":"Grok-session recover","enabled":false}' \
+  > "$WORKDIR/agent-data/agents/test/automations/grok-session-recover/automation.json"
+rm -f "$WORKDIR/watchdog/watchdog.pid"
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 36000)"
+
+assert_exit 0 "M5 ok when oauth ok" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 \
+      GROK_AUTH_FILE="$GROK_AUTH_FILE" \
+      SAND_HOST_DIR="$WORKDIR/sand-host" \
+      FLEET_AGENT_DATA="$WORKDIR/agent-data" \
+      FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid" \
+      "$CUTOVER"
+assert_grep "$OUT_DIR/M5_ok_when_oauth_ok.stdout" 'hook: present' "M5 hook present"
+assert_grep "$OUT_DIR/M5_ok_when_oauth_ok.stdout" 'watchdog: down' "M5 watchdog down"
+assert_grep "$OUT_DIR/M5_ok_when_oauth_ok.stdout" 'recover: paused' "M5 recover paused"
+
+write_auth "$GROK_AUTH_FILE" "$(iso_offset -60)"
+assert_exit 2 "M5 non-zero when oauth expired" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 \
+      GROK_AUTH_FILE="$GROK_AUTH_FILE" \
+      SAND_HOST_DIR="$WORKDIR/sand-host" \
+      FLEET_AGENT_DATA="$WORKDIR/agent-data" \
+      FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid" \
+      "$CUTOVER"
+
+echo "$$" > "$WORKDIR/watchdog/watchdog.pid"
+write_auth "$GROK_AUTH_FILE" "$(iso_offset 36000)"
+assert_exit 0 "M5 reports watchdog alive (does not start it)" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 \
+      GROK_AUTH_FILE="$GROK_AUTH_FILE" \
+      SAND_HOST_DIR="$WORKDIR/sand-host" \
+      FLEET_AGENT_DATA="$WORKDIR/agent-data" \
+      FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid" \
+      "$CUTOVER"
+assert_grep "$OUT_DIR/M5_reports_watchdog_alive__does_not_start_it_.stdout" 'watchdog: alive' "M5 watchdog alive"
+
+assert_exit 2 "M5 refuses --go" \
+  env FLEET_ALLOW_TEST_OVERRIDES=1 \
+      GROK_AUTH_FILE="$GROK_AUTH_FILE" \
+      SAND_HOST_DIR="$WORKDIR/sand-host" \
+      FLEET_AGENT_DATA="$WORKDIR/agent-data" \
+      FLEET_WATCHDOG_PIDFILE="$WORKDIR/watchdog/watchdog.pid" \
+      "$CUTOVER" --go
+
+assert_not_grep "$CUTOVER" 'restart-host' "M5 does not restart-host"
+assert_not_grep "$CUTOVER" 'adapters.sh recover' "M5 does not call recover"
+assert_not_grep "$CUTOVER" 'fleet-heavy' "M5 does not call fleet-heavy"
+
+# --- docs ---
+assert_grep "$ROOT/docs/GROK_AUTH_KEEPALIVE.md" 'Two-door' "M4 names two-door rule"
+assert_grep "$ROOT/docs/GROK_AUTH_KEEPALIVE.md" 'grok login --device-auth' "M4 names human login"
+assert_grep "$ROOT/docs/GROK_AUTH_KEEPALIVE.md" 'M1' "M4 names M1"
+assert_grep "$ROOT/docs/GROK_AUTH_KEEPALIVE.md" 'Do not' "M4 has do-not for recover/watchdog"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/token-expired.py
+++ b/scripts/token-expired.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Grok OAuth expiry helper. Never prints tokens, refresh_token, or email.
+
+Default (watchdog contract): print 1 if expired, 0 otherwise.
+  python3 token-expired.py /path/to/auth.json
+
+Probe (M1): print exists/has_key/expires_at/seconds_left/status. No secrets.
+  python3 token-expired.py --probe /path/to/auth.json
+  exit 0 ok, 1 soon (<2h), 2 expired/missing
+"""
+import datetime
+import json
+import sys
+from pathlib import Path
+
+SOON_SECONDS = 7200  # 2 hours — documented in docs/GROK_AUTH_KEEPALIVE.md
+
+
+def parse_expires(exp):
+    if exp is None or exp == "":
+        return None
+    try:
+        if isinstance(exp, (int, float)):
+            ts = float(exp)
+            if ts > 1e12:
+                ts /= 1000.0
+            return datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+        dt = datetime.datetime.fromisoformat(str(exp).replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt
+    except Exception:
+        return None
+
+
+def pick_entry(data):
+    if not isinstance(data, dict):
+        return None
+    for k, v in data.items():
+        if isinstance(v, dict) and v.get("key") and (
+            "auth.x.ai" in str(k) or v.get("auth_mode") == "oidc"
+        ):
+            return v
+    for v in data.values():
+        if isinstance(v, dict) and v.get("key"):
+            return v
+    return None
+
+
+def load_data(path):
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return None
+
+
+def default_mode(path):
+    data = load_data(path)
+    if not isinstance(data, dict):
+        print("0")
+        return
+    now = datetime.datetime.now(datetime.timezone.utc)
+    expired = False
+    for entry in data.values():
+        if not isinstance(entry, dict):
+            continue
+        dt = parse_expires(entry.get("expires_at") or entry.get("expiresAt"))
+        if dt is None:
+            continue
+        if dt < now:
+            expired = True
+            break
+    print("1" if expired else "0")
+
+
+def probe_mode(path):
+    exists = "yes" if path.is_file() else "no"
+    has_key = "false"
+    expires_at = ""
+    seconds_left = ""
+    status = "EXPIRED"
+    exit_code = 2
+
+    if path.is_file():
+        data = load_data(path)
+        entry = pick_entry(data) if data is not None else None
+        if entry and entry.get("key"):
+            has_key = "true"
+            raw = entry.get("expires_at") or entry.get("expiresAt")
+            dt = parse_expires(raw)
+            if dt is None:
+                status = "ok"
+                exit_code = 0
+            else:
+                if isinstance(raw, str):
+                    expires_at = raw
+                else:
+                    expires_at = dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                now = datetime.datetime.now(datetime.timezone.utc)
+                seconds_left = str(int((dt - now).total_seconds()))
+                left = int(seconds_left)
+                if left < 0:
+                    status = "EXPIRED"
+                    exit_code = 2
+                elif left < SOON_SECONDS:
+                    status = "soon"
+                    exit_code = 1
+                else:
+                    status = "ok"
+                    exit_code = 0
+
+    print(
+        "exists=%s has_key=%s expires_at=%s seconds_left=%s status=%s"
+        % (exists, has_key, expires_at, seconds_left, status)
+    )
+    raise SystemExit(exit_code)
+
+
+def main(argv):
+    if len(argv) >= 2 and argv[1] == "--probe":
+        target = Path(argv[2]) if len(argv) > 2 else Path("")
+        probe_mode(target)
+        return
+    if len(argv) < 2:
+        print("0")
+        return
+    default_mode(Path(argv[1]))
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -794,9 +794,10 @@ function normalizeEffort(v) {
   return s;
 }
 
-/** UUIDs that must never silently default to grok-heavy without an explicit policy row. */
+/** UUIDs that must never silently default without an explicit policy row. */
 const REQUIRE_EXPLICIT_ROW = {
-  "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9": "codex", // Pump — never accidental Heavy
+  // Pump: this slice grok-heavy high; next module flips the row to Codex.
+  "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9": "pump-row",
 };
 
 /**

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -1217,6 +1217,28 @@ function createXaiPromptSession(options) {
   const sessionOptions = opts.sessionOptions;
   const inference = resolveAgentInference(sessionOptions, opts);
 
+  // Slice 0: log key paths only (no values) when SAND_XAI_DUMP_SESSION_KEYS=1
+  if (truthy(process.env.SAND_XAI_DUMP_SESSION_KEYS)) {
+    try {
+      const keys = [];
+      const walk = (obj, prefix, depth) => {
+        if (!obj || typeof obj !== "object" || depth > 3) return;
+        for (const k of Object.keys(obj)) {
+          const p = prefix ? `${prefix}.${k}` : k;
+          keys.push(p);
+          const v = obj[k];
+          if (v && typeof v === "object" && !Array.isArray(v) && depth < 2) walk(v, p, depth + 1);
+        }
+      };
+      walk(sessionOptions || {}, "", 0);
+      console.error(
+        `[sand-xai] sessionOptions keys (no values): ${keys.slice(0, 80).join(", ") || "(none)"} | extracted agentId=${inference.agentId || "(empty)"}`
+      );
+    } catch (e) {
+      console.error(`[sand-xai] sessionOptions key dump failed: ${e && e.message ? e.message : e}`);
+    }
+  }
+
   console.error(
     `[sand-xai] agent=${inference.agentId || inference.label} effort=${inference.effort || "none"} model=${inference.model} provider=${inference.provider}`
   );

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -200,31 +200,93 @@ function mapModelId(requestedModel) {
   return raw;
 }
 
-function grokSessionToken() {
+const GROK_AUTH_SOON_SECONDS = 7200; // 2h — same constant as scripts/token-expired.py
+
+function parseGrokExpiresAt(exp) {
+  if (exp == null || exp === "") return null;
+  if (typeof exp === "number" && Number.isFinite(exp)) {
+    let ts = exp;
+    if (ts > 1e12) ts /= 1000;
+    return ts;
+  }
+  const ms = Date.parse(String(exp).replace("Z", "+00:00"));
+  if (Number.isNaN(ms)) return null;
+  return ms / 1000;
+}
+
+function pickGrokAuthEntry(data) {
+  if (!data || typeof data !== "object") return null;
+  for (const [k, v] of Object.entries(data)) {
+    if (v && typeof v === "object" && v.key && (k.includes("auth.x.ai") || v.auth_mode === "oidc")) {
+      return v;
+    }
+  }
+  for (const v of Object.values(data)) {
+    if (v && typeof v === "object" && v.key) return v;
+  }
+  return null;
+}
+
+function readGrokAuth() {
   const authPath = env("GROK_AUTH_FILE", path.join(os.homedir(), ".grok", "auth.json"));
+  const result = {
+    authPath,
+    exists: false,
+    has_key: false,
+    expires_at: "",
+    seconds_left: null,
+    status: "EXPIRED",
+    entry: null,
+  };
+  if (!fs.existsSync(authPath)) return result;
+  result.exists = true;
   let data;
   try {
     data = JSON.parse(fs.readFileSync(authPath, "utf8"));
   } catch {
+    return result;
+  }
+  const entry = pickGrokAuthEntry(data);
+  if (!entry || !entry.key) return result;
+  result.entry = entry;
+  result.has_key = true;
+  const raw = entry.expires_at || entry.expiresAt;
+  const epoch = parseGrokExpiresAt(raw);
+  if (epoch == null) {
+    result.status = "ok";
+    return result;
+  }
+  result.expires_at = typeof raw === "string" ? String(raw) : new Date(epoch * 1000).toISOString();
+  result.seconds_left = Math.floor(epoch - Date.now() / 1000);
+  if (result.seconds_left < 0) result.status = "EXPIRED";
+  else if (result.seconds_left < GROK_AUTH_SOON_SECONDS) result.status = "soon";
+  else result.status = "ok";
+  return result;
+}
+
+/** Probe only — never includes key / refresh_token / email. */
+function grokAuthProbe() {
+  const r = readGrokAuth();
+  return {
+    exists: r.exists,
+    has_key: r.has_key,
+    expires_at: r.expires_at,
+    seconds_left: r.seconds_left,
+    status: r.status,
+  };
+}
+
+function grokSessionToken() {
+  const r = readGrokAuth();
+  if (r.status === "EXPIRED") {
+    if (r.has_key) {
+      console.error(
+        `[sand-xai] GROK_AUTH_EXPIRED expires_at=${r.expires_at} seconds_left=${r.seconds_left}`
+      );
+    }
     return "";
   }
-  if (!data || typeof data !== "object") return "";
-  let entry = null;
-  for (const [k, v] of Object.entries(data)) {
-    if (v && typeof v === "object" && v.key && (k.includes("auth.x.ai") || v.auth_mode === "oidc")) {
-      entry = v;
-      break;
-    }
-  }
-  if (!entry) {
-    for (const v of Object.values(data)) {
-      if (v && typeof v === "object" && v.key) {
-        entry = v;
-        break;
-      }
-    }
-  }
-  return entry && entry.key ? String(entry.key) : "";
+  return r.entry && r.entry.key ? String(r.entry.key) : "";
 }
 
 function resolveAuth() {
@@ -237,6 +299,14 @@ function resolveAuth() {
       baseUrl: env("SAND_XAI_BASE_URL", "https://api.x.ai/v1").replace(/\/+$/, ""),
       extraHeaders: {},
     };
+  }
+  const probe = grokAuthProbe();
+  if (probe.status === "EXPIRED" && probe.has_key) {
+    const err = new Error(
+      `GROK_AUTH_EXPIRED expires_at=${probe.expires_at} seconds_left=${probe.seconds_left}`
+    );
+    err.code = "GROK_AUTH_EXPIRED";
+    throw err;
   }
   const session = grokSessionToken();
   return {
@@ -1274,6 +1344,9 @@ module.exports = {
   loadAgentPolicy,
   resolveSessionAuth,
   policyFilePath,
+  grokSessionToken,
+  grokAuthProbe,
+  resolveAuth,
 };
 
 if (require.main === module) {

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -767,10 +767,20 @@ function isUuid(s) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(s || "").trim());
 }
 
+function callAllowlistedGetter(obj, name) {
+  if (!obj || typeof obj[name] !== "function") return "";
+  try {
+    return obj[name]();
+  } catch {
+    return "";
+  }
+}
+
 function extractAgentId(sessionOptions, options) {
   // Allowlist only — do NOT walk source_agent_id / target_agent_id /agent/i keys.
   const opts = options || {};
   const so = sessionOptions || {};
+  const ho = opts.hostOptions || opts.options2 || null;
   const candidates = [
     opts.agentId,
     so.agentId,
@@ -778,6 +788,13 @@ function extractAgentId(sessionOptions, options) {
     so.agent_id,
     so.agent && so.agent.id,
     so.agent && so.agent.agentId,
+    ho && ho.agentId,
+    ho && ho.agentID,
+    ho && ho.agent_id,
+    ho && ho.agent && ho.agent.id,
+    ho && ho.agent && ho.agent.agentId,
+    callAllowlistedGetter(ho, "getAgentId"),
+    callAllowlistedGetter(ho, "getAgentID"),
   ];
   for (const c of candidates) {
     const s = asString(c).trim();
@@ -825,8 +842,33 @@ function resolveAgentInference(sessionOptions, options) {
   }
 
   const defaults = policy.default || {};
+
+  // Slice-0 FAIL: live sessionOptions has no agentId. Do not apply a per-agent
+  // row (never silent high / never Pump-row). Fleet default only.
+  if (!agentId) {
+    console.error(
+      `[sand-xai] REFUSE per-agent overlay: empty agentId — no identity on sessionOptions/hostOptions; using fleet default medium (not high)`
+    );
+    const provider =
+      asString(defaults.provider || "grok-heavy").toLowerCase() || "grok-heavy";
+    const model =
+      asString(defaults.model || "").trim() || env("SAND_XAI_MODEL", "grok-4.6");
+    let effort = normalizeEffort(defaults.effort);
+    if (effort == null && provider === "grok-heavy") {
+      effort = normalizeEffort(env("SAND_XAI_REASONING_EFFORT", "medium")) || "medium";
+    }
+    return {
+      agentId: "",
+      label: "unknown",
+      provider,
+      model,
+      effort,
+      known: false,
+    };
+  }
+
   const row =
-    agentId && policy.agents && typeof policy.agents === "object"
+    policy.agents && typeof policy.agents === "object"
       ? policy.agents[agentId] || policy.agents[agentId.toLowerCase()]
       : null;
 
@@ -1291,19 +1333,41 @@ function createXaiPromptSession(options) {
   // Slice 0: log key paths only (no values) when SAND_XAI_DUMP_SESSION_KEYS=1
   if (truthy(process.env.SAND_XAI_DUMP_SESSION_KEYS)) {
     try {
-      const keys = [];
-      const walk = (obj, prefix, depth) => {
-        if (!obj || typeof obj !== "object" || depth > 3) return;
-        for (const k of Object.keys(obj)) {
-          const p = prefix ? `${prefix}.${k}` : k;
-          keys.push(p);
-          const v = obj[k];
-          if (v && typeof v === "object" && !Array.isArray(v) && depth < 2) walk(v, p, depth + 1);
+      const collectKeys = (obj) => {
+        const keys = [];
+        if (!obj || typeof obj !== "object") return keys;
+        const seen = new Set();
+        const add = (k) => {
+          if (!k || seen.has(k)) return;
+          seen.add(k);
+          keys.push(k);
+        };
+        try {
+          Object.keys(obj).forEach(add);
+        } catch {
+          /* ignore */
         }
+        try {
+          Object.getOwnPropertyNames(obj).forEach(add);
+        } catch {
+          /* ignore */
+        }
+        try {
+          const proto = Object.getPrototypeOf(obj);
+          if (proto && proto !== Object.prototype) {
+            Object.getOwnPropertyNames(proto).forEach((k) => {
+              if (k !== "constructor") add(`proto.${k}`);
+            });
+          }
+        } catch {
+          /* ignore */
+        }
+        return keys.slice(0, 80);
       };
-      walk(sessionOptions || {}, "", 0);
+      const soKeys = collectKeys(sessionOptions);
+      const hoKeys = collectKeys(opts.hostOptions);
       console.error(
-        `[sand-xai] sessionOptions keys (no values): ${keys.slice(0, 80).join(", ") || "(none)"} | extracted agentId=${inference.agentId || "(empty)"}`
+        `[sand-xai] sessionOptions keys (no values): ${soKeys.join(", ") || "(none)"} | hostOptions keys: ${hoKeys.join(", ") || "(none)"} | extracted agentId=${inference.agentId || "(empty)"}`
       );
     } catch (e) {
       console.error(`[sand-xai] sessionOptions key dump failed: ${e && e.message ? e.message : e}`);

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -698,6 +698,7 @@ function isUuid(s) {
 }
 
 function extractAgentId(sessionOptions, options) {
+  // Allowlist only — do NOT walk source_agent_id / target_agent_id /agent/i keys.
   const opts = options || {};
   const so = sessionOptions || {};
   const candidates = [
@@ -705,31 +706,12 @@ function extractAgentId(sessionOptions, options) {
     so.agentId,
     so.agentID,
     so.agent_id,
-    so.agentUuid,
-    so.agentUUID,
     so.agent && so.agent.id,
     so.agent && so.agent.agentId,
-    so.conversation && so.conversation.agentId,
-    so.conversation && so.conversation.agent && so.conversation.agent.id,
-    so.metadata && so.metadata.agentId,
-    so.sandAgentId,
-    so.boxAgentId,
   ];
   for (const c of candidates) {
     const s = asString(c).trim();
     if (isUuid(s)) return s.toLowerCase();
-  }
-  // shallow walk: any uuid under a key that looks agent-related
-  const stack = [so];
-  let depth = 0;
-  while (stack.length && depth < 40) {
-    depth += 1;
-    const cur = stack.pop();
-    if (!cur || typeof cur !== "object") continue;
-    for (const [k, v] of Object.entries(cur)) {
-      if (typeof v === "string" && /agent/i.test(k) && isUuid(v)) return v.toLowerCase();
-      if (v && typeof v === "object" && depth < 6) stack.push(v);
-    }
   }
   return "";
 }
@@ -742,24 +724,61 @@ function normalizeEffort(v) {
   return s;
 }
 
+/** UUIDs that must never silently default to grok-heavy without an explicit policy row. */
+const REQUIRE_EXPLICIT_ROW = {
+  "8ae9a103-cfa2-406d-9bf3-eea00ca5b3a9": "codex", // Pump — never accidental Heavy
+};
+
 /**
  * Resolve per-agent overlay. Locals only — never mutates process.env.
- * Unknown UUID → default effort medium + WARN.
+ * Missing/unreadable policy → provider policy-missing (fail closed, not grok-heavy).
+ * Unknown UUID with policy present → default effort medium + WARN.
  */
 function resolveAgentInference(sessionOptions, options) {
   const policy = loadAgentPolicy();
   const agentId = extractAgentId(sessionOptions, options);
-  const defaults = (policy && policy.default) || {};
+  const labelHint = agentId || "unknown";
+
+  if (!policy) {
+    console.error(
+      `[sand-xai] REFUSE policy missing/unreadable at ${policyFilePath()} — fail-closed (no silent grok-heavy)`
+    );
+    return {
+      agentId: agentId || "",
+      label: labelHint,
+      provider: "policy-missing",
+      model: "none",
+      effort: undefined,
+      known: false,
+    };
+  }
+
+  const defaults = policy.default || {};
   const row =
-    agentId && policy && policy.agents && typeof policy.agents === "object"
+    agentId && policy.agents && typeof policy.agents === "object"
       ? policy.agents[agentId] || policy.agents[agentId.toLowerCase()]
       : null;
 
-  if (agentId && policy && policy.agents && !row) {
+  if (agentId && REQUIRE_EXPLICIT_ROW[agentId] && !row) {
+    console.error(
+      `[sand-xai] REFUSE agent ${agentId} requires an explicit policy row (expected ${REQUIRE_EXPLICIT_ROW[agentId]}) — not grok-heavy`
+    );
+    return {
+      agentId,
+      label: labelHint,
+      provider: "policy-row-missing",
+      model: "none",
+      effort: undefined,
+      known: false,
+    };
+  }
+
+  if (agentId && policy.agents && !row) {
     console.error(`[sand-xai] WARN unknown agent uuid=${agentId} — using default effort=medium`);
   }
 
-  const provider = asString((row && row.provider) || defaults.provider || "grok-heavy").toLowerCase() || "grok-heavy";
+  const provider =
+    asString((row && row.provider) || defaults.provider || "grok-heavy").toLowerCase() || "grok-heavy";
   const model =
     asString((row && row.model) || defaults.model || "").trim() ||
     env("SAND_XAI_MODEL", "grok-4.6");
@@ -841,6 +860,13 @@ function probeCodexProxy(baseUrl) {
 }
 
 async function resolveSessionAuth(inference) {
+  if (inference.provider === "policy-missing" || inference.provider === "policy-row-missing") {
+    const err = new Error(
+      `agent-inference-policy required (${inference.provider}) — copy examples/agent-inference-policy.json to sand-data; will not default Pump/codex seats to Grok`
+    );
+    err.code = "POLICY_REQUIRED";
+    throw err;
+  }
   if (inference.provider === "codex") {
     const auth = resolveCodexAuth();
     const ok = await probeCodexProxy(auth.baseUrl);

--- a/xai-prompt-session.cjs
+++ b/xai-prompt-session.cjs
@@ -659,6 +659,210 @@ function reasoningEffort() {
   return s;
 }
 
+/** Policy path — read only; never write SAND_* back into process.env. */
+function policyFilePath() {
+  return (
+    process.env.SAND_AGENT_INFERENCE_POLICY ||
+    path.join(process.env.SAND_DATA_ROOT || path.join(os.homedir(), "sand-data"), "agent-inference-policy.json")
+  );
+}
+
+let _policyCache = { mtimeMs: -1, path: "", data: null };
+
+function loadAgentPolicy() {
+  const file = policyFilePath();
+  let st;
+  try {
+    st = fs.statSync(file);
+  } catch {
+    _policyCache = { mtimeMs: -1, path: file, data: null };
+    return null;
+  }
+  if (_policyCache.path === file && _policyCache.mtimeMs === st.mtimeMs && _policyCache.data) {
+    return _policyCache.data;
+  }
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (err) {
+    console.error(`[sand-xai] policy unreadable at ${file}: ${err && err.message ? err.message : err}`);
+    _policyCache = { mtimeMs: st.mtimeMs, path: file, data: null };
+    return null;
+  }
+  _policyCache = { mtimeMs: st.mtimeMs, path: file, data };
+  return data;
+}
+
+function isUuid(s) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(s || "").trim());
+}
+
+function extractAgentId(sessionOptions, options) {
+  const opts = options || {};
+  const so = sessionOptions || {};
+  const candidates = [
+    opts.agentId,
+    so.agentId,
+    so.agentID,
+    so.agent_id,
+    so.agentUuid,
+    so.agentUUID,
+    so.agent && so.agent.id,
+    so.agent && so.agent.agentId,
+    so.conversation && so.conversation.agentId,
+    so.conversation && so.conversation.agent && so.conversation.agent.id,
+    so.metadata && so.metadata.agentId,
+    so.sandAgentId,
+    so.boxAgentId,
+  ];
+  for (const c of candidates) {
+    const s = asString(c).trim();
+    if (isUuid(s)) return s.toLowerCase();
+  }
+  // shallow walk: any uuid under a key that looks agent-related
+  const stack = [so];
+  let depth = 0;
+  while (stack.length && depth < 40) {
+    depth += 1;
+    const cur = stack.pop();
+    if (!cur || typeof cur !== "object") continue;
+    for (const [k, v] of Object.entries(cur)) {
+      if (typeof v === "string" && /agent/i.test(k) && isUuid(v)) return v.toLowerCase();
+      if (v && typeof v === "object" && depth < 6) stack.push(v);
+    }
+  }
+  return "";
+}
+
+function normalizeEffort(v) {
+  if (v == null || v === "") return undefined;
+  const s = String(v).toLowerCase().trim();
+  if (s === "off" || s === "none" || s === "disabled") return undefined;
+  if (s === "low" || s === "medium" || s === "high" || s === "xhigh") return s;
+  return s;
+}
+
+/**
+ * Resolve per-agent overlay. Locals only — never mutates process.env.
+ * Unknown UUID → default effort medium + WARN.
+ */
+function resolveAgentInference(sessionOptions, options) {
+  const policy = loadAgentPolicy();
+  const agentId = extractAgentId(sessionOptions, options);
+  const defaults = (policy && policy.default) || {};
+  const row =
+    agentId && policy && policy.agents && typeof policy.agents === "object"
+      ? policy.agents[agentId] || policy.agents[agentId.toLowerCase()]
+      : null;
+
+  if (agentId && policy && policy.agents && !row) {
+    console.error(`[sand-xai] WARN unknown agent uuid=${agentId} — using default effort=medium`);
+  }
+
+  const provider = asString((row && row.provider) || defaults.provider || "grok-heavy").toLowerCase() || "grok-heavy";
+  const model =
+    asString((row && row.model) || defaults.model || "").trim() ||
+    env("SAND_XAI_MODEL", "grok-4.6");
+  let effort = normalizeEffort((row && row.effort) != null ? row.effort : defaults.effort);
+  if (effort == null && provider === "grok-heavy") {
+    effort = normalizeEffort(env("SAND_XAI_REASONING_EFFORT", "medium")) || "medium";
+  }
+  const label = asString((row && row.label) || agentId || "unknown");
+
+  return {
+    agentId: agentId || "",
+    label,
+    provider,
+    model,
+    effort,
+    known: Boolean(row),
+  };
+}
+
+function resolveGrokHeavyAuth() {
+  const auth = resolveAuth();
+  return { ...auth, provider: "grok-heavy" };
+}
+
+function resolveCodexAuth() {
+  const authFile = process.env.CODEX_AUTH_FILE || path.join(os.homedir(), ".codex", "auth.json");
+  if (!fs.existsSync(authFile)) {
+    const err = new Error(
+      "Pump/Codex requires ~/.codex/auth.json — run from desktop terminal: codex login --device-auth (do not fall back to Grok)"
+    );
+    err.code = "CODEX_AUTH_MISSING";
+    throw err;
+  }
+  const baseUrl = (
+    process.env.SAND_CODEX_BASE_URL ||
+    "http://127.0.0.1:10531/v1"
+  ).replace(/\/+$/, "");
+  return {
+    mode: "key",
+    token: "openai-oauth",
+    baseUrl,
+    extraHeaders: {},
+    provider: "codex",
+    authFile,
+  };
+}
+
+/** Async probe: Codex proxy must answer. Fail closed — never route Pump to Grok. */
+function probeCodexProxy(baseUrl) {
+  return new Promise((resolve) => {
+    try {
+      const u = new URL(`${baseUrl}/models`);
+      const lib = u.protocol === "https:" ? https : http;
+      const req = lib.request(
+        {
+          protocol: u.protocol,
+          hostname: u.hostname,
+          port: u.port || (u.protocol === "https:" ? 443 : 80),
+          path: `${u.pathname}${u.search}`,
+          method: "GET",
+          timeout: 2000,
+          headers: { Authorization: "Bearer openai-oauth" },
+        },
+        (res) => {
+          res.resume();
+          resolve(res.statusCode && res.statusCode < 500);
+        }
+      );
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.on("error", () => resolve(false));
+      req.end();
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+async function resolveSessionAuth(inference) {
+  if (inference.provider === "codex") {
+    const auth = resolveCodexAuth();
+    const ok = await probeCodexProxy(auth.baseUrl);
+    if (!ok) {
+      const err = new Error(
+        `Codex/openai-oauth proxy not reachable at ${auth.baseUrl} — start it (adapters start openai-oauth). Pump will NOT fall back to Grok.`
+      );
+      err.code = "CODEX_PROXY_DOWN";
+      throw err;
+    }
+    return auth;
+  }
+  if (inference.provider !== "grok-heavy") {
+    const err = new Error(
+      `unsupported provider '${inference.provider}' in agent-inference-policy (allowed: grok-heavy, codex)`
+    );
+    err.code = "BAD_PROVIDER";
+    throw err;
+  }
+  return resolveGrokHeavyAuth();
+}
+
 function httpPostStream(urlString, { headers, body, onData }) {
   const u = new URL(urlString);
   const lib = u.protocol === "https:" ? https : http;
@@ -765,7 +969,7 @@ function errorResult(modelId, invocationId, err) {
   };
 }
 
-async function runStream({ model, messages, tools, invocationId, auth }) {
+async function runStream({ model, messages, tools, invocationId, auth, effort }) {
   const converted = trimConvertedMessages(convertMessages(messages), model);
   debugDump(messages, converted);
   const openaiTools = convertTools(tools);
@@ -790,8 +994,14 @@ async function runStream({ model, messages, tools, invocationId, auth }) {
   }
   const mt = maxTokens();
   if (mt != null) body.max_tokens = mt;
-  const effort = thinkingEnabled() ? reasoningEffort() : undefined;
-  if (effort) body.reasoning_effort = effort;
+  // Per-session effort from policy (locals). Do not read/write process.env here for effort.
+  let useEffort = effort;
+  if (useEffort == null && auth.provider !== "codex") {
+    useEffort = thinkingEnabled() ? reasoningEffort() : undefined;
+  }
+  if (useEffort && auth.provider !== "codex") {
+    body.reasoning_effort = useEffort;
+  }
 
   const url = `${auth.baseUrl}/chat/completions`;
   const toolAcc = new Map();
@@ -930,13 +1140,21 @@ function createExecutor(session) {
       }
       const processing = (async () => {
         loadEnvFile();
-        const auth = resolveAuth();
-        const model = mapModelId(session.requestedModel);
+        const inference = session.inference || resolveAgentInference(session.sessionOptions, {
+          agentId: session.agentId,
+        });
+        let auth;
+        try {
+          auth = await resolveSessionAuth(inference);
+        } catch (err) {
+          return errorResult(inference.model || "unknown", invocationId, err);
+        }
+        const model = inference.model || mapModelId(session.requestedModel);
         if (auth.mode === "none") {
           return errorResult(
             model,
             invocationId,
-            new Error("no XAI_API_KEY and no ~/.grok/auth.json session — run adapters use … or grok login")
+            new Error("no XAI_API_KEY and no ~/.grok/auth.json session — run grok login --device-auth")
           );
         }
         return runStream({
@@ -945,6 +1163,7 @@ function createExecutor(session) {
           tools,
           invocationId,
           auth,
+          effort: inference.effort,
         });
       })();
 
@@ -969,20 +1188,23 @@ function createXaiPromptSession(options) {
   loadEnvFile();
   const opts = options || {};
   const requestedModel = opts.requestedModel;
-  const model = mapModelId(requestedModel);
-  const auth = resolveAuth();
-  const thinking = env("SAND_XAI_THINKING", "disabled");
-  const effort = env("SAND_XAI_REASONING_EFFORT", "");
+  const sessionOptions = opts.sessionOptions;
+  const inference = resolveAgentInference(sessionOptions, opts);
+
   console.error(
-    `[sand-xai] session model=${model} auth=${auth.mode} base=${auth.baseUrl} thinking=${thinking}` +
-      (effort ? ` effort=${effort}` : "")
+    `[sand-xai] agent=${inference.agentId || inference.label} effort=${inference.effort || "none"} model=${inference.model} provider=${inference.provider}`
   );
+
   const session = {
     requestedModel,
     onRequestId: opts.onRequestId,
-    sessionOptions: opts.sessionOptions,
+    sessionOptions,
+    agentId: inference.agentId,
+    inference,
     getModelId() {
-      return mapModelId(this.requestedModel);
+      return this.inference && this.inference.model
+        ? this.inference.model
+        : mapModelId(this.requestedModel);
     },
     getExecutor(initialMessages) {
       const ex = createExecutor(session);
@@ -999,6 +1221,11 @@ module.exports = {
   normalizeToolParameters,
   mapModelId,
   trimConvertedMessages,
+  extractAgentId,
+  resolveAgentInference,
+  loadAgentPolicy,
+  resolveSessionAuth,
+  policyFilePath,
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary

OAuth keepalive **on top of** [BlockedPath#4](https://github.com/BlockedPath/grok-bot-setup/pull/4) (`feat/agent-inference-policy` @ `79c6a41`). Same `xai-prompt-session.cjs` as the effort overlay — not a parallel fight over that file.

Docs packet: [panrix/grok-bot-setup#1](https://github.com/panrix/grok-bot-setup/pull/1). Also cites [BlockedPath#3](https://github.com/BlockedPath/grok-bot-setup/pull/3) (fleet-heavy, still gated `--go`).

**Not live. No `--go`. Recover stays paused. Watchdog stays dead.**

### Keep from #4 (not rebuilt)

- CoS + Development → high grok-4.6; Finance → low; default → medium
- Pump UUID → Codex only (`127.0.0.1:10531`), fail closed
- Policy-missing / no Pump row must not silently go Heavy
- `extractAgentId` allowlist only
- No writing `SAND_XAI_*` into `process.env`
- Slice-0 `SAND_XAI_DUMP_SESSION_KEYS=1` keys-only dump (empty `agentId` still Heavy medium — live hole, not skipped)

### This PR (M1–M5)

| Module | What |
|---|---|
| M1 `bin/grok-auth-status` | Probe. `ok` / `soon` (<2h) / `EXPIRED`. Never prints tokens. |
| M2 `scripts/refresh-grok-if-expired.sh` | `skip` / `grok models` / `refresh-failed`. Never device-auth, never deletes `auth.json`. |
| M3 `xai-prompt-session.cjs` | Expired `expires_at` → do **not** send the dead key. Throws `GROK_AUTH_EXPIRED`. |
| M4 `docs/GROK_AUTH_KEEPALIVE.md` | Ping-only CoS recipe. Two-door rule. |
| M5 `bin/grok-auth-cutover-status` | Hook + oauth + watchdog pid + recover armed? Never `--go`. |

## Tests run

- `bash ./scripts/test-grok-auth-keepalive.sh` → **45/45** (stub fixtures)
- `bash ./scripts/test-agent-inference-policy.sh` → **14/14**
- `npm test` → fleet 23/23 + policy 14/14 + keepalive 45/45
- `node --check xai-prompt-session.cjs`
- `shellcheck -S error` on the new bash

## Tests **not** run

- No `grok login --device-auth` / live `auth.x.ai`
- No `adapters use` / fleet-heavy `--go` / SIGTERM
- No host-hook-watchdog start
- No grok-session-recover enable
- No box hook deploy / host restart

`grok models` actually rotating `expires_at` is still unproven on the live CLI — stubbed both outcomes. Human fix remains `/home/box/.grok/bin/grok login --device-auth`.

CoS: please critique like #4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added fleet-wide Heavy cutover and status commands with dry-run defaults and safety checks.
  - Added Grok authentication status, expiry detection, and non-interactive refresh tools.
  - Added per-agent provider, model, and reasoning-effort configuration.
  - Added fail-closed handling for expired authentication and unavailable inference policies.

- **Documentation**
  - Added operational guides and example configuration for fleet cutovers, authentication keepalive, inference policies, and desktop hook upgrades.

- **Tests**
  - Added automated coverage for cutover safety, authentication handling, policy resolution, and shell scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->